### PR TITLE
Hold one catalog connection per scan phase, not three

### DIFF
--- a/src/polars_ducklake/_catalog.py
+++ b/src/polars_ducklake/_catalog.py
@@ -30,6 +30,7 @@ canonical catalog SQL pattern this code follows.
 from __future__ import annotations
 
 import shlex
+import threading
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from datetime import datetime
@@ -270,6 +271,18 @@ def _require_duckdb_engine() -> None:
         ) from exc
 
 
+# Process-wide cache of engines built from string inputs. Keyed by the
+# post-translation SQLAlchemy URL so ``ducklake:sqlite:foo.db`` and
+# ``sqlite:///foo.db`` collapse to the same entry. Pre-built ``Engine``
+# arguments bypass the cache entirely — the caller owns disposal.
+#
+# Engines are kept for process lifetime; they hold a connection pool
+# (typically idle) but no checked-out resources between scans, so the
+# memory cost is small compared to the per-scan handshake we save.
+_ENGINE_CACHE: dict[str, Engine] = {}
+_ENGINE_CACHE_LOCK = threading.Lock()
+
+
 def _engine_from_metadata_catalog(metadata_catalog: str | Engine) -> Engine:
     """Normalise any catalog input into a SQLAlchemy ``Engine``.
 
@@ -279,6 +292,9 @@ def _engine_from_metadata_catalog(metadata_catalog: str | Engine) -> Engine:
     * an already-built :class:`sqlalchemy.engine.Engine`,
     * a SQLAlchemy URL string,
     * a DuckLake-native ``ducklake:...`` connection string.
+
+    String inputs are memoised by their post-translation URL so successive
+    scans against the same catalog reuse one SQLAlchemy pool.
     """
     if isinstance(metadata_catalog, Engine):
         return metadata_catalog
@@ -295,15 +311,28 @@ def _engine_from_metadata_catalog(metadata_catalog: str | Engine) -> Engine:
         else metadata_catalog
     )
 
+    with _ENGINE_CACHE_LOCK:
+        cached = _ENGINE_CACHE.get(url)
+    if cached is not None:
+        return cached
+
     if url.startswith("duckdb:"):
         _require_duckdb_engine()
 
     try:
-        return sqlalchemy.create_engine(url)
+        engine = sqlalchemy.create_engine(url)
     except Exception as exc:
         raise ValueError(
             f"Could not build SQLAlchemy engine from {metadata_catalog!r}: {exc}"
         ) from exc
+
+    # Two threads racing on the same URL each build their own engine; the
+    # loser's engine is disposed so its pool is released cleanly.
+    with _ENGINE_CACHE_LOCK:
+        existing = _ENGINE_CACHE.setdefault(url, engine)
+    if existing is not engine:
+        engine.dispose()
+    return existing
 
 
 # ---------------------------------------------------------------------------
@@ -349,6 +378,17 @@ class CatalogReader(AbstractContextManager["CatalogReader"]):
         See the module docstring for accepted forms.
         """
         return cls(_engine_from_metadata_catalog(metadata_catalog))
+
+    @classmethod
+    def from_engine(cls, engine: Engine) -> CatalogReader:
+        """Build a reader directly from an already-resolved engine.
+
+        Used inside the scan after :func:`_engine_from_metadata_catalog`
+        has resolved the user's argument once — successive readers in
+        the same scan skip the parse/cache lookup that
+        :meth:`from_metadata_catalog` performs.
+        """
+        return cls(engine)
 
     @property
     def engine(self) -> Engine:

--- a/src/polars_ducklake/scan.py
+++ b/src/polars_ducklake/scan.py
@@ -41,6 +41,7 @@ from polars_ducklake._catalog import (
     FileColumnStat,
     SchemaInfo,
     TableInfo,
+    _engine_from_metadata_catalog,
 )
 from polars_ducklake._predicate import extract_clauses, file_can_match
 from polars_ducklake.paths import PathSegment, resolve_path
@@ -179,13 +180,23 @@ def scan_ducklake(
 
     schema, table = _resolve_table_identifier(schema=schema, table=table)
 
-    # Eager: resolve identity (snapshot/schema/table) and refuse inlined data.
-    # These are cheap (3-4 small SELECTs) and we keep them eager so the
-    # public exception API stays stable: scan_ducklake() raises LookupError
-    # / NotImplementedError directly, instead of polars wrapping them in
-    # ComputeError at .collect() time. Heavy catalog work (column expansion,
-    # file enumeration, plan construction) is deferred to _PlanContext.
-    with CatalogReader.from_metadata_catalog(metadata_catalog) as reader:
+    # Resolve the user's catalog argument into an Engine exactly once. The
+    # engine is memoised by URL inside _engine_from_metadata_catalog, so
+    # repeat scans against the same catalog reuse one SQLAlchemy pool.
+    engine = _engine_from_metadata_catalog(metadata_catalog)
+
+    # Eager: resolve identity (snapshot/schema/table), expand the column
+    # list, and refuse inlined data. The column expansion is small and
+    # lets the IO-source schema callable answer purely from cached state,
+    # which means Polars' planner doesn't need its own catalog connection.
+    # The remaining heavy work (data-file enumeration, delete linkage,
+    # per-file plan construction) is deferred to :meth:`_PlanContext.resolve`
+    # and runs on a second connection opened inside the IO-source generator.
+    #
+    # Eager exceptions also keep the public API stable: scan_ducklake()
+    # raises LookupError / NotImplementedError directly, instead of polars
+    # wrapping them in ComputeError at .collect() time.
+    with CatalogReader.from_engine(engine) as reader:
         target_snapshot = reader.resolve_snapshot_id(snapshot_id=snapshot_id, as_of=as_of)
         schema_info = reader.resolve_schema(schema_name=schema, snapshot_id=target_snapshot)
         table_info = reader.resolve_table(
@@ -202,14 +213,20 @@ def scan_ducklake(
                 "DATA_INLINING_ROW_LIMIT=0 on the catalog or run the writer's "
                 "inline-flush command to materialize inlined rows into Parquet."
             )
+        target_columns = _build_target_columns(
+            reader.fetch_columns_with_nested(
+                table_id=table_info.table_id, snapshot_id=target_snapshot
+            )
+        )
 
     ctx = _PlanContext(
-        metadata_catalog=metadata_catalog,
+        engine=engine,
         schema_name=schema,
         table_name=table,
         schema_info=schema_info,
         table_info=table_info,
         snapshot_id=target_snapshot,
+        target_columns=target_columns,
         storage_options=storage_options,
         data_path=data_path,
     )
@@ -439,98 +456,114 @@ class _PlanContext:
     files/deletes) is deferred to :meth:`resolve` and memoized so the
     schema callable and the read generator can both reach for it without
     paying for it twice.
+
+    ``engine`` is the SQLAlchemy ``Engine`` resolved once at scan-build
+    time. Storing the engine (rather than the user's original argument)
+    means we never re-parse a connection string and we share the engine's
+    pool across every catalog touch in this scan.
     """
 
-    metadata_catalog: str | Engine
+    engine: Engine
     schema_name: str
     table_name: str
     schema_info: SchemaInfo
     table_info: TableInfo
     snapshot_id: int
+    target_columns: list[_TargetColumn]
     storage_options: dict[str, Any] | None
     data_path: str | None
     _resolved: _Resolved | None = field(default=None, init=False, repr=False)
 
-    def resolve(self) -> _Resolved:
+    def resolve(self, reader: CatalogReader | None = None) -> _Resolved:
+        """Run the deferred catalog phase, optionally on a caller-owned reader.
+
+        When ``reader`` is supplied, all queries run on that connection —
+        the generator passes the reader it already opened so the deferred
+        phase consumes one connection end-to-end. When ``reader`` is
+        ``None`` (e.g. the schema callable invoked outside any generator
+        run), this method opens its own short-lived reader.
+        """
         if self._resolved is not None:
             return self._resolved
+        if reader is not None:
+            self._resolved = self._do_resolve(reader)
+            return self._resolved
+        with CatalogReader.from_engine(self.engine) as r:
+            self._resolved = self._do_resolve(r)
+        return self._resolved
 
+    def _do_resolve(self, reader: CatalogReader) -> _Resolved:
         table_id = self.table_info.table_id
-        with CatalogReader.from_metadata_catalog(self.metadata_catalog) as reader:
-            target_columns = _build_target_columns(
-                reader.fetch_columns_with_nested(
-                    table_id=table_id, snapshot_id=self.snapshot_id
-                )
-            )
-            polars_schema = {tc.name: tc.dtype for tc in target_columns}
+        target_columns = self.target_columns
+        polars_schema = {tc.name: tc.dtype for tc in target_columns}
 
-            data_files = reader.fetch_data_files(
-                table_id=table_id, snapshot_id=self.snapshot_id
-            )
-            delete_files = reader.fetch_delete_files(
-                table_id=table_id, snapshot_id=self.snapshot_id
-            )
-            effective_data_path = (
-                self.data_path if self.data_path is not None else reader.fetch_data_path()
+        data_files = reader.fetch_data_files(
+            table_id=table_id, snapshot_id=self.snapshot_id
+        )
+        delete_files = reader.fetch_delete_files(
+            table_id=table_id, snapshot_id=self.snapshot_id
+        )
+        effective_data_path = (
+            self.data_path if self.data_path is not None else reader.fetch_data_path()
+        )
+
+        schema_segment = PathSegment(
+            path=self.schema_info.path,
+            is_relative=self.schema_info.path_is_relative,
+        )
+        table_segment = PathSegment(
+            path=self.table_info.path,
+            is_relative=self.table_info.path_is_relative,
+        )
+
+        def _resolve_path(path: str, path_is_relative: bool) -> str:
+            return resolve_path(
+                path=path,
+                path_is_relative=path_is_relative,
+                data_path=effective_data_path,
+                schema_segment=schema_segment,
+                table_segment=table_segment,
             )
 
-            schema_segment = PathSegment(
-                path=self.schema_info.path,
-                is_relative=self.schema_info.path_is_relative,
+        # Group delete files by the data file they apply to. The catalog
+        # link via data_file_id is authoritative: even if a delete-file
+        # Parquet were to carry rows for multiple data files, the catalog
+        # tells us which data file each catalog row applies to.
+        deletes_by_file: dict[int, list[str]] = defaultdict(list)
+        for df in delete_files:
+            deletes_by_file[df.data_file_id].append(
+                _resolve_path(df.path, df.path_is_relative)
             )
-            table_segment = PathSegment(
-                path=self.table_info.path,
-                is_relative=self.table_info.path_is_relative,
+
+        per_file_plans = [
+            _plan_file(
+                reader,
+                table_id=table_id,
+                file=f,
+                target_snapshot=self.snapshot_id,
+                target_columns=target_columns,
+                full_path=_resolve_path(f.path, f.path_is_relative),
+                delete_paths=deletes_by_file.get(f.data_file_id, []),
             )
+            for f in data_files
+        ]
 
-            def _resolve_path(path: str, path_is_relative: bool) -> str:
-                return resolve_path(
-                    path=path,
-                    path_is_relative=path_is_relative,
-                    data_path=effective_data_path,
-                    schema_segment=schema_segment,
-                    table_segment=table_segment,
-                )
-
-            # Group delete files by the data file they apply to. The catalog
-            # link via data_file_id is authoritative: even if a delete-file
-            # Parquet were to carry rows for multiple data files, the catalog
-            # tells us which data file each catalog row applies to.
-            deletes_by_file: dict[int, list[str]] = defaultdict(list)
-            for df in delete_files:
-                deletes_by_file[df.data_file_id].append(
-                    _resolve_path(df.path, df.path_is_relative)
-                )
-
-            per_file_plans = [
-                _plan_file(
-                    reader,
-                    table_id=table_id,
-                    file=f,
-                    target_snapshot=self.snapshot_id,
-                    target_columns=target_columns,
-                    full_path=_resolve_path(f.path, f.path_is_relative),
-                    delete_paths=deletes_by_file.get(f.data_file_id, []),
-                )
-                for f in data_files
-            ]
-
-        self._resolved = _Resolved(
+        return _Resolved(
             target_columns=target_columns,
             polars_schema=polars_schema,
             per_file_plans=per_file_plans,
             has_delete_files=bool(delete_files),
         )
-        return self._resolved
 
     def _polars_schema(self) -> pl.Schema:
         """Schema callable handed to ``register_io_source``.
 
-        Polars invokes this lazily — the catalog is not touched until the
-        engine actually needs the schema (e.g. at ``.collect()`` or when
-        the user reads ``.schema``).
+        Returns from the eagerly-cached column list — Polars' planner
+        invokes this during query optimization and we don't want to open
+        a separate catalog connection just for the schema. File-level
+        work still defers to :meth:`resolve` on the generator's reader.
         """
-        return pl.Schema(self.resolve().polars_schema)
+        return pl.Schema({tc.name: tc.dtype for tc in self.target_columns})
 
     def build_lazyframe(self) -> pl.LazyFrame:
         """Wire the IO plugin and return a LazyFrame.
@@ -569,41 +602,47 @@ def _make_generator(
         n_rows: int | None,
         _batch_size: int | None,
     ) -> Iterator[pl.DataFrame]:
-        r = ctx.resolve()
-        plans = r.per_file_plans
-        if predicate is not None:
-            # Catalog-level pruning: drop whole files whose per-column
-            # min/max in the catalog rule out the predicate. Files we
-            # can't decide on (unsupported predicate, missing stats)
-            # fall through and Polars handles the filter itself.
-            plans = _prune_files_by_stats(ctx, r, plans, predicate)
-
-        remaining = n_rows
-        for plan in plans:
-            if remaining is not None and remaining <= 0:
-                return
-            lf = plan.build(storage_options=ctx.storage_options)
+        # Open one catalog connection for the whole deferred phase: plan
+        # resolution (if not already memoised) and predicate pruning both
+        # run on this reader. The connection stays open across yields and
+        # is released by the context manager when the consumer exhausts
+        # or closes the generator.
+        with CatalogReader.from_engine(ctx.engine) as reader:
+            r = ctx.resolve(reader=reader)
+            plans = r.per_file_plans
             if predicate is not None:
-                # Polars pushes the filter into scan_parquet → row-group
-                # skipping via the file's own min/max stats.
-                lf = lf.filter(predicate)
-            if with_columns is not None:
-                # Projection pushdown likewise reaches scan_parquet.
-                lf = lf.select(with_columns)
-            if remaining is not None:
-                lf = lf.head(remaining)
-            df = lf.collect()
-            if df.height == 0:
-                continue
-            if remaining is not None:
-                remaining -= df.height
-            yield df
+                # Catalog-level pruning: drop whole files whose per-column
+                # min/max in the catalog rule out the predicate. Files we
+                # can't decide on (unsupported predicate, missing stats)
+                # fall through and Polars handles the filter itself.
+                plans = _prune_files_by_stats(reader, r, plans, predicate)
+
+            remaining = n_rows
+            for plan in plans:
+                if remaining is not None and remaining <= 0:
+                    return
+                lf = plan.build(storage_options=ctx.storage_options)
+                if predicate is not None:
+                    # Polars pushes the filter into scan_parquet → row-group
+                    # skipping via the file's own min/max stats.
+                    lf = lf.filter(predicate)
+                if with_columns is not None:
+                    # Projection pushdown likewise reaches scan_parquet.
+                    lf = lf.select(with_columns)
+                if remaining is not None:
+                    lf = lf.head(remaining)
+                df = lf.collect()
+                if df.height == 0:
+                    continue
+                if remaining is not None:
+                    remaining -= df.height
+                yield df
 
     return _gen
 
 
 def _prune_files_by_stats(
-    ctx: _PlanContext,
+    reader: CatalogReader,
     resolved: _Resolved,
     plans: list[_FilePlan],
     predicate: pl.Expr,
@@ -619,6 +658,9 @@ def _prune_files_by_stats(
 
     Otherwise, fetches stats once for every (referenced column, file)
     pair and runs :func:`file_can_match` per file.
+
+    ``reader`` is the deferred-phase reader opened by the generator —
+    we share the same connection rather than opening a third one.
     """
     clauses = extract_clauses(predicate)
     if not clauses:
@@ -637,11 +679,10 @@ def _prune_files_by_stats(
         return plans
 
     file_ids = [p.data_file_id for p in plans]
-    with CatalogReader.from_metadata_catalog(ctx.metadata_catalog) as reader:
-        stats = reader.fetch_file_stats(
-            data_file_ids=file_ids,
-            column_ids=sorted(referenced_column_ids),
-        )
+    stats = reader.fetch_file_stats(
+        data_file_ids=file_ids,
+        column_ids=sorted(referenced_column_ids),
+    )
 
     # Group stats by data_file_id for the per-file check.
     by_file: dict[int, dict[int, FileColumnStat]] = defaultdict(dict)

--- a/tests/test_connection_count.py
+++ b/tests/test_connection_count.py
@@ -1,0 +1,179 @@
+"""Tests for issue #5: one connection per scan phase, not three.
+
+Verifies:
+
+* :func:`_engine_from_metadata_catalog` memoises by URL across scans.
+* :func:`scan_ducklake().collect()` opens exactly two SQLAlchemy
+  ``Connection``\\ s — one for the eager identity resolution and one
+  shared across the deferred plan/prune/file-list phase.
+
+The ``engine_connect`` SQLAlchemy event fires on every ``engine.connect()``
+call, so it's the right hook for counting checkouts (not ``connect``,
+which fires only on new DBAPI connections).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+import pytest
+import sqlalchemy
+from sqlalchemy import event
+
+import polars_ducklake as pdl
+from polars_ducklake._catalog import (
+    _ENGINE_CACHE,
+    _engine_from_metadata_catalog,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_engine_cache() -> Any:
+    """Each test starts with a clean engine cache.
+
+    Engines are kept for process lifetime in production; in tests we drop
+    them between cases so independent tests don't share pools (and so
+    the cache-hit count assertions are meaningful).
+    """
+    _ENGINE_CACHE.clear()
+    yield
+    for engine in list(_ENGINE_CACHE.values()):
+        engine.dispose()
+    _ENGINE_CACHE.clear()
+
+
+def _count_connects(engine: sqlalchemy.engine.Engine) -> dict[str, int]:
+    counts = {"n": 0}
+
+    @event.listens_for(engine, "engine_connect")
+    def _on_connect(_conn: Any) -> None:
+        counts["n"] += 1
+
+    return counts
+
+
+class TestEngineCache:
+    def test_same_url_returns_same_engine(self, builder: Any) -> None:
+        e1 = _engine_from_metadata_catalog(builder.url)
+        e2 = _engine_from_metadata_catalog(builder.url)
+        assert e1 is e2
+
+    def test_ducklake_prefix_normalises_to_same_entry(
+        self, tmp_path: Any
+    ) -> None:
+        path = tmp_path / "lake.db"
+        sa_url = f"sqlite:///{path}"
+        ducklake_url = f"ducklake:sqlite:{path}"
+        e1 = _engine_from_metadata_catalog(ducklake_url)
+        e2 = _engine_from_metadata_catalog(sa_url)
+        assert e1 is e2
+
+    def test_prebuilt_engine_bypasses_cache(self) -> None:
+        eng = sqlalchemy.create_engine("sqlite:///:memory:")
+        assert _engine_from_metadata_catalog(eng) is eng
+        # Pre-built engines are not interned: passing the same engine
+        # twice still returns the caller's instance, and nothing was added
+        # to the cache.
+        assert _engine_from_metadata_catalog(eng) is eng
+        assert eng not in _ENGINE_CACHE.values()
+
+    def test_create_engine_called_once_per_url(
+        self,
+        empty_table_lake: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from polars_ducklake import _catalog as catalog_mod
+
+        builder = empty_table_lake["builder"]
+        calls = {"n": 0}
+        real = sqlalchemy.create_engine
+
+        def counting(*args: Any, **kw: Any) -> Any:
+            calls["n"] += 1
+            return real(*args, **kw)
+
+        monkeypatch.setattr(catalog_mod.sqlalchemy, "create_engine", counting)
+        # Cache was cleared by the autouse fixture, so the first scan
+        # builds an engine and the second hits the cache.
+        pdl.scan_ducklake(builder.url, table="empty_t").collect()
+        pdl.scan_ducklake(builder.url, table="empty_t").collect()
+        assert calls["n"] == 1
+
+
+class TestConnectionCount:
+    """Issue #5: scans should open one connection per phase, not three."""
+
+    def _scan_table(self, builder: Any) -> tuple[Any, dict[str, int]]:
+        """Build an engine, attach a counter, and return both."""
+        engine = _engine_from_metadata_catalog(builder.url)
+        counts = _count_connects(engine)
+        return engine, counts
+
+    def test_collect_opens_two_connections(
+        self, single_file_lake: dict[str, Any]
+    ) -> None:
+        builder = single_file_lake["builder"]
+        engine, counts = self._scan_table(builder)
+        df = pdl.scan_ducklake(engine, table="sales").collect()
+        assert df.height == single_file_lake["row_count"]
+        # One eager connection (identity resolution) + one deferred
+        # connection (plan + file list).
+        assert counts["n"] == 2
+
+    def test_collect_with_predicate_still_two_connections(
+        self, builder: Any
+    ) -> None:
+        # Build a predicate-prunable lake inline so the prune path runs.
+        snap = builder.take_snapshot()
+        schema_id = builder.add_schema(name="main", begin_snapshot=snap)
+        table_id = builder.add_table(
+            schema_id=schema_id,
+            name="t",
+            begin_snapshot=snap,
+            columns=[("id", "INTEGER"), ("v", "VARCHAR")],
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"id": [1, 2, 3], "v": ["a", "b", "c"]}),
+            compute_stats=True,
+        )
+
+        engine, counts = self._scan_table(builder)
+        df = (
+            pdl.scan_ducklake(engine, table="t")
+            .filter(pl.col("id") == 2)
+            .collect()
+        )
+        assert df["v"].to_list() == ["b"]
+        # Prune now runs on the deferred reader instead of opening its
+        # own — still 2 total.
+        assert counts["n"] == 2
+
+    def test_schema_only_opens_one_connection(
+        self, single_file_lake: dict[str, Any]
+    ) -> None:
+        # Reading just the schema (no collect) only drives the eager
+        # phase — column list is cached on _PlanContext, so the schema
+        # callable answers without touching the catalog.
+        builder = single_file_lake["builder"]
+        engine, counts = self._scan_table(builder)
+        lf = pdl.scan_ducklake(engine, table="sales")
+        _ = lf.collect_schema()
+        assert counts["n"] == 1
+
+    def test_time_travel_two_connections(
+        self, multi_snapshot_lake: dict[str, Any]
+    ) -> None:
+        builder = multi_snapshot_lake["builder"]
+        engine, counts = self._scan_table(builder)
+        df = (
+            pdl.scan_ducklake(
+                engine, table="rolling", snapshot_id=multi_snapshot_lake["snap2"]
+            )
+            .sort("id")
+            .collect()
+        )
+        assert df["id"].to_list() == [1, 2, 3, 4]
+        assert counts["n"] == 2


### PR DESCRIPTION
## Summary

- Cache SQLAlchemy engines by post-translation URL in `_engine_from_metadata_catalog` so successive scans against the same catalog reuse one pool. Pre-built `Engine` arguments still bypass the cache (caller owns disposal).
- Pull column expansion into the eager phase of `scan_ducklake()` so `_PlanContext._polars_schema()` answers from cached state — Polars' planner no longer triggers its own catalog connection.
- The IO-source generator now opens one `CatalogReader`, passes it to `_PlanContext.resolve(reader=...)`, and reuses it inside `_prune_files_by_stats(reader, ...)`. The deferred phase is one connection end-to-end.
- `_PlanContext` carries `engine: Engine` and `target_columns` instead of the raw user input.

Connection count per `scan_ducklake().collect()`:
- Before: 3 (eager identity, plan resolve, prune) — and a fresh `create_engine` each time when input is a string.
- After: 2 (eager identity+columns, deferred plan+prune+files). Schema-only path: 1.

Closes #5.

## Design notes

I went with two short-lived connections instead of the issue's "1 connection per scan" target. The 1-connection approach requires keeping a connection alive for the LazyFrame's lifetime via `weakref.finalize`, which on Postgres holds an idle transaction across whatever delay separates `scan_ducklake()` from `.collect()` — bad for VACUUM, exposed to `idle_in_transaction_session_timeout`, and a pool starvation risk if LazyFrames leak. Single-SQL-txn read consistency isn't load-bearing here because `snapshot_id` is captured eagerly and pinned as a bind parameter on every catalog query, so MVCC visibility is determined by the snapshot pin rather than the transaction boundary.

## Test plan

- [x] New `tests/test_connection_count.py` with `engine_connect`-listener-based assertions:
  - 2 conns per `.collect()` on single-file, predicate, and time-travel paths
  - 1 conn for schema-only (`collect_schema()`)
  - Engine cache: same URL → same engine; `ducklake:` and SQLAlchemy URL forms collapse; pre-built engines bypass; `create_engine` called once across two scans against the same URL
- [x] Full unit suite (237 tests) passes
- [ ] Integration suite (Postgres / MySQL / DuckDB / MinIO) — not run locally; relies on services from `tests/integration/_*.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)