### PR TITLE
Catalog-side file pruning via single CTE query (#4)

### DIFF
--- a/src/polars_ducklake/_catalog.py
+++ b/src/polars_ducklake/_catalog.py
@@ -34,11 +34,17 @@ import threading
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
+
+from polars_ducklake._file_query import (
+    PartitionField,
+    build_files_query,
+)
+from polars_ducklake._predicate import _AtomicClause
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -121,21 +127,21 @@ class DeleteFileInfo:
 
 
 @dataclass(frozen=True)
-class FileColumnStat:
-    """Per-file, per-column statistics from ``ducklake_file_column_stats``.
+class CandidateFile:
+    """One data file returned by :meth:`CatalogReader.fetch_candidate_files`.
 
-    ``min_value`` and ``max_value`` are the *raw* VARCHAR forms written by
-    the writer. Coercing them to typed Python values is the predicate
-    pruner's job (it knows the column's logical type).
+    Result of the single CTE-shaped enumeration query: visibility,
+    predicate-pushed stats pruning, identity-partition pruning, and
+    delete-file linkage are all already applied.
     """
 
     data_file_id: int
-    column_id: int
-    min_value: str | None
-    max_value: str | None
-    null_count: int | None
-    value_count: int | None
-    contains_nan: bool | None
+    path: str
+    path_is_relative: bool
+    record_count: int
+    begin_snapshot: int
+    partial_max: int | None
+    delete_files: tuple[DeleteFileInfo, ...]
 
 
 # ---------------------------------------------------------------------------
@@ -624,47 +630,111 @@ class CatalogReader(AbstractContextManager["CatalogReader"]):
             for r in rows
         ]
 
-    def fetch_file_stats(
-        self, *, data_file_ids: list[int], column_ids: list[int]
-    ) -> list[FileColumnStat]:
-        """Fetch min/max/null counts for the given (file, column) pairs.
+    def fetch_partition_spec(
+        self, *, table_id: int, snapshot_id: int
+    ) -> list[PartitionField]:
+        """Load the active partition spec for a table at a snapshot.
 
-        Visibility is established by the caller (``data_file_ids`` should
-        already be filtered to files visible at the read snapshot), so
-        this method does not apply MVCC filters of its own — it's a pure
-        lookup against ``ducklake_file_column_stats``.
+        Joins ``ducklake_partition_info``, ``ducklake_partition_column``,
+        and ``ducklake_column`` so each :class:`PartitionField` carries
+        the user-visible column name and catalog ``column_type`` needed
+        to translate predicates against ``partition_value``.
 
-        Returns an empty list if either input is empty (so callers don't
-        have to special-case "no predicate columns" before calling).
+        Returns ``[]`` for unpartitioned tables. The result is in
+        ``partition_key_index`` order.
         """
-        if not data_file_ids or not column_ids:
-            return []
-        stmt = text(
-            """
-            SELECT data_file_id, column_id, min_value, max_value,
-                   null_count, value_count, contains_nan
-            FROM ducklake_file_column_stats
-            WHERE data_file_id IN :file_ids
-              AND column_id IN :column_ids
-            """
-        ).bindparams(
-            sqlalchemy.bindparam("file_ids", expanding=True),
-            sqlalchemy.bindparam("column_ids", expanding=True),
-        )
         rows = self._active_conn.execute(
-            stmt, {"file_ids": data_file_ids, "column_ids": column_ids}
+            text(
+                f"""
+                SELECT pc.partition_key_index, pc.column_id, pc.transform,
+                       c.column_name, c.column_type
+                FROM ducklake_partition_info pi
+                JOIN ducklake_partition_column pc
+                  ON pc.partition_id = pi.partition_id
+                JOIN ducklake_column c
+                  ON c.column_id = pc.column_id
+                  AND :snapshot_id >= c.begin_snapshot
+                  AND (c.end_snapshot IS NULL OR :snapshot_id < c.end_snapshot)
+                WHERE pi.table_id = :table_id
+                  AND :snapshot_id >= pi.begin_snapshot
+                  AND (pi.end_snapshot IS NULL OR :snapshot_id < pi.end_snapshot)
+                ORDER BY pc.partition_key_index
+                """
+            ),
+            {"table_id": table_id, "snapshot_id": snapshot_id},
         ).all()
         return [
-            FileColumnStat(
-                data_file_id=int(r[0]),
+            PartitionField(
                 column_id=int(r[1]),
-                min_value=str(r[2]) if r[2] is not None else None,
-                max_value=str(r[3]) if r[3] is not None else None,
-                null_count=int(r[4]) if r[4] is not None else None,
-                value_count=int(r[5]) if r[5] is not None else None,
-                contains_nan=bool(r[6]) if r[6] is not None else None,
+                column_name=str(r[3]),
+                column_type=str(r[4]),
+                partition_key_index=int(r[0]),
+                transform=str(r[2]),
             )
             for r in rows
+        ]
+
+    def fetch_candidate_files(
+        self,
+        *,
+        table_id: int,
+        snapshot_id: int,
+        column_meta: dict[str, tuple[int, str]],
+        partition_spec: list[PartitionField],
+        clauses: list[_AtomicClause],
+    ) -> list[CandidateFile]:
+        """Run the single CTE-shaped file-enumeration query.
+
+        Replaces the prior 3-query pattern (data files + delete files +
+        per-file stats). Returns one :class:`CandidateFile` per surviving
+        data file, with all attached delete files grouped on the file.
+        """
+        sql, params = build_files_query(
+            table_id=table_id,
+            snapshot_id=snapshot_id,
+            column_meta=column_meta,
+            partition_spec=partition_spec,
+            clauses=clauses,
+            dialect=self.dialect,
+        )
+        rows = self._active_conn.execute(text(sql), params).all()
+
+        # Group multi-row delete-file results onto their data files,
+        # preserving file_order from the ORDER BY.
+        per_file: dict[int, dict[str, Any]] = {}
+        for r in rows:
+            data_file_id = int(r[0])
+            entry = per_file.get(data_file_id)
+            if entry is None:
+                entry = {
+                    "data_file_id": data_file_id,
+                    "path": str(r[1]),
+                    "path_is_relative": bool(r[2]),
+                    "record_count": int(r[3]) if r[3] is not None else 0,
+                    "begin_snapshot": int(r[4]),
+                    "partial_max": int(r[5]) if r[5] is not None else None,
+                    "delete_files": [],
+                }
+                per_file[data_file_id] = entry
+            if r[6] is not None:
+                entry["delete_files"].append(
+                    DeleteFileInfo(
+                        data_file_id=data_file_id,
+                        path=str(r[6]),
+                        path_is_relative=bool(r[7]),
+                    )
+                )
+        return [
+            CandidateFile(
+                data_file_id=e["data_file_id"],
+                path=e["path"],
+                path_is_relative=e["path_is_relative"],
+                record_count=e["record_count"],
+                begin_snapshot=e["begin_snapshot"],
+                partial_max=e["partial_max"],
+                delete_files=tuple(e["delete_files"]),
+            )
+            for e in per_file.values()
         ]
 
     # -- inlined data + global metadata --------------------------------------

--- a/src/polars_ducklake/_file_query.py
+++ b/src/polars_ducklake/_file_query.py
@@ -1,0 +1,490 @@
+"""Catalog-side file enumeration query (issue #4).
+
+A single CTE-shaped query that replaces the prior three-query pattern
+(fetch_data_files + fetch_delete_files + fetch_file_stats). Predicate
+clauses translate to per-column stats CTEs; identity-partition clauses
+translate to per-partition-key CTEs. Clauses we can't translate are
+silently dropped — Polars still applies the full predicate at read
+time, so a dropped clause widens the candidate file set without
+affecting correctness.
+
+This module is pure SQL string construction; it issues no queries. The
+actual execution lives on :class:`polars_ducklake._catalog.CatalogReader`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Mapping
+
+from polars_ducklake._predicate import _AtomicClause
+
+
+# ---------------------------------------------------------------------------
+# Catalog column-type families
+# ---------------------------------------------------------------------------
+
+_INT_COLUMN_TYPES = frozenset({
+    "tinyint", "smallint", "integer", "int", "bigint", "hugeint",
+    "utinyint", "usmallint", "uinteger", "ubigint",
+    "int8", "int16", "int32", "int64",
+    "uint8", "uint16", "uint32", "uint64",
+})
+_FLOAT_COLUMN_TYPES = frozenset({
+    "float", "double", "real", "float4", "float8", "float32", "float64",
+})
+_STRING_COLUMN_TYPES = frozenset({"varchar", "string", "text"})
+
+
+# Per-dialect CAST type names for translating stat min/max VARCHARs to a
+# typed comparable. Empty string means "no cast" — stats compare as
+# string for varchar/boolean (boolean stats are written as "0"/"1", and
+# both the literal and the stat are bound/stored as those same strings).
+_CAST_BY_DIALECT: dict[str, dict[str, str]] = {
+    "sqlite":     {"int": "INTEGER", "float": "REAL",             "date": "",     "timestamp": ""},
+    "postgresql": {"int": "BIGINT",  "float": "DOUBLE PRECISION", "date": "DATE", "timestamp": "TIMESTAMP"},
+    "mysql":      {"int": "SIGNED",  "float": "DOUBLE",           "date": "DATE", "timestamp": "DATETIME"},
+    "duckdb":     {"int": "BIGINT",  "float": "DOUBLE",           "date": "DATE", "timestamp": "TIMESTAMP"},
+}
+
+# Fallback dialect for unknowns. ANSI-ish; works on most engines.
+_DEFAULT_DIALECT = "postgresql"
+
+
+def _column_family(column_type: str) -> str | None:
+    """Map a catalog ``column_type`` string to a CAST family.
+
+    Returns ``None`` for column types we don't know how to compare
+    (caller drops the clause). ``""`` family means "no cast needed".
+    """
+    ct = column_type.strip().lower()
+    if ct in _STRING_COLUMN_TYPES or ct == "boolean":
+        return ""
+    if ct in _INT_COLUMN_TYPES:
+        return "int"
+    if ct in _FLOAT_COLUMN_TYPES:
+        return "float"
+    if ct == "date":
+        return "date"
+    if ct.startswith("timestamp"):
+        return "timestamp"
+    return None
+
+
+def _typed_stat_expr(stat_col: str, column_type: str, dialect: str) -> str | None:
+    """SQL expression that yields ``stat_col`` cast to a comparable type.
+
+    Returns ``None`` for column types we don't know how to translate.
+    Returns ``stat_col`` unchanged for varchar/boolean (string compare).
+    Otherwise wraps in a dialect-appropriate ``CAST(... AS T)``.
+    """
+    family = _column_family(column_type)
+    if family is None:
+        return None
+    if family == "":
+        return stat_col
+    cast_map = _CAST_BY_DIALECT.get(dialect, _CAST_BY_DIALECT[_DEFAULT_DIALECT])
+    cast_type = cast_map.get(family, "")
+    if not cast_type:
+        return stat_col
+    return f"CAST({stat_col} AS {cast_type})"
+
+
+# ---------------------------------------------------------------------------
+# Per-clause translation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ClauseSql:
+    """SQL keep-condition for one atomic clause + its bind params.
+
+    ``sql`` is meant to be AND'd inside a per-column stats CTE. It
+    already wraps the bound check in conservative-keep guards (NaN-
+    tainted, NULL min/max), so a row is kept whenever stats are
+    incomplete or unreliable.
+    """
+
+    sql: str
+    params: dict[str, Any]
+
+
+def translate_clause(
+    clause: _AtomicClause,
+    *,
+    column_type: str,
+    dialect: str,
+    param_prefix: str,
+) -> _ClauseSql | None:
+    """Translate one :class:`_AtomicClause` to a stats keep-condition.
+
+    Returns ``None`` when ``column_type`` isn't one we know how to
+    translate (e.g. unsupported type, struct/list). ``param_prefix``
+    namespaces the bind parameter names so multiple clauses on the same
+    column can coexist in one CTE.
+    """
+    op = clause.op
+    if op == "is_null":
+        return _ClauseSql(
+            sql="(null_count IS NULL OR null_count > 0)",
+            params={},
+        )
+    if op == "is_not_null":
+        return _ClauseSql(
+            sql=(
+                "(null_count IS NULL OR value_count IS NULL "
+                "OR null_count < value_count)"
+            ),
+            params={},
+        )
+
+    typed_min = _typed_stat_expr("min_value", column_type, dialect)
+    typed_max = _typed_stat_expr("max_value", column_type, dialect)
+    if typed_min is None or typed_max is None:
+        return None
+
+    bind_value = _bind_value_for(clause.literal, column_type)
+    if bind_value is _BIND_UNSUPPORTED:
+        return None
+
+    p_name = f"{param_prefix}_v"
+    p_ref = f":{p_name}"
+
+    if op == "eq":
+        bound = f"({typed_min} <= {p_ref} AND {typed_max} >= {p_ref})"
+    elif op == "ne":
+        # Drop only when every non-null value is provably ``lit``:
+        # min == max == lit AND value_count > null_count. Keep otherwise.
+        bound = (
+            f"({typed_min} <> {p_ref} OR {typed_max} <> {p_ref} "
+            f"OR null_count IS NULL OR value_count IS NULL "
+            f"OR value_count <= null_count)"
+        )
+    elif op == "lt":
+        bound = f"({typed_min} < {p_ref})"
+    elif op == "le":
+        bound = f"({typed_min} <= {p_ref})"
+    elif op == "gt":
+        bound = f"({typed_max} > {p_ref})"
+    elif op == "ge":
+        bound = f"({typed_max} >= {p_ref})"
+    else:
+        return None
+
+    # Conservative-keep guards: NaN poisons numeric ordering, missing
+    # min/max means "no info". Either case keeps the file regardless of
+    # the bound check.
+    nan_guard = "(contains_nan IS NOT NULL AND contains_nan = 1)"
+    null_guard = "(min_value IS NULL OR max_value IS NULL)"
+    full = f"({nan_guard} OR {null_guard} OR {bound})"
+    return _ClauseSql(sql=full, params={p_name: bind_value})
+
+
+# Sentinel for "literal cannot be bound" — distinguishes from the
+# legitimate value ``None``.
+_BIND_UNSUPPORTED: Any = object()
+
+
+def _bind_value_for(literal: Any, column_type: str) -> Any:
+    """Convert an extractor literal to a bind value for the typed CAST.
+
+    Booleans on a ``boolean`` catalog column become the same ``"0"``/``"1"``
+    strings the writer puts in ``min_value``/``max_value``. Everything
+    else passes through and SQLAlchemy binds by Python type.
+    """
+    if isinstance(literal, bool):
+        # bool is a subclass of int; intercept before the int branch.
+        if column_type.strip().lower() == "boolean":
+            return "1" if literal else "0"
+        return _BIND_UNSUPPORTED
+    if isinstance(literal, (int, float, str, date, datetime)):
+        return literal
+    return _BIND_UNSUPPORTED
+
+
+# ---------------------------------------------------------------------------
+# Partition spec
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PartitionField:
+    """One partition column descriptor at a given snapshot.
+
+    ``transform`` is the DuckLake partition transform name (``identity``,
+    ``year``, ``month``, ``day``, ``bucket``, etc.). Only ``identity`` is
+    pushable in this iteration; the rest are kept on the field for
+    future work but produce no CTE today.
+    """
+
+    column_id: int
+    column_name: str
+    column_type: str
+    partition_key_index: int
+    transform: str
+
+
+# ---------------------------------------------------------------------------
+# Full query builder
+# ---------------------------------------------------------------------------
+
+
+# MVCC visibility fragment used inside both visible_files and
+# visible_deletes CTEs. References the bind ``:snapshot_id``.
+_MVCC = (
+    ":snapshot_id >= begin_snapshot AND "
+    "(end_snapshot IS NULL OR :snapshot_id < end_snapshot)"
+)
+
+
+def build_files_query(
+    *,
+    table_id: int,
+    snapshot_id: int,
+    column_meta: Mapping[str, tuple[int, str]],
+    partition_spec: list[PartitionField],
+    clauses: list[_AtomicClause],
+    dialect: str,
+) -> tuple[str, dict[str, Any]]:
+    """Compose the single CTE-shaped file enumeration query.
+
+    Returns ``(sql_text, bind_params)`` ready for SQLAlchemy ``text()``.
+    The result is files visible at ``snapshot_id`` for ``table_id``,
+    LEFT-joined to their delete files, with predicate pushdown into
+    per-column stats CTEs and identity-partition CTEs.
+
+    ``column_meta`` maps user-visible column name → (column_id,
+    column_type). Clauses on columns not in ``column_meta`` are dropped.
+    ``clauses`` is the lossy output of :func:`extract_clauses`; this
+    builder only tightens the file set, never widens it.
+
+    The returned rows are ordered by ``ducklake_data_file.file_order``
+    so callers see files in writer-order; multiple delete files for the
+    same data file appear as multiple rows (Python-side aggregation).
+    """
+    params: dict[str, Any] = {
+        "table_id": table_id,
+        "snapshot_id": snapshot_id,
+    }
+
+    clauses_by_col: dict[str, list[_AtomicClause]] = {}
+    for clause in clauses:
+        clauses_by_col.setdefault(clause.column, []).append(clause)
+
+    stats_ctes: list[str] = []
+    partition_ctes: list[str] = []
+    where_filters: list[str] = []
+
+    partition_by_column: dict[str, PartitionField] = {
+        f.column_name: f
+        for f in partition_spec
+        if f.transform == "identity"
+    }
+
+    for col_name, col_clauses in clauses_by_col.items():
+        col_ref = column_meta.get(col_name)
+        if col_ref is not None:
+            cte_sql, cte_params, alias = _build_stats_cte(
+                column_id=col_ref[0],
+                column_type=col_ref[1],
+                clauses=col_clauses,
+                dialect=dialect,
+            )
+            if cte_sql is not None:
+                stats_ctes.append(cte_sql)
+                params.update(cte_params)
+                where_filters.append(
+                    f"vf.data_file_id IN (SELECT data_file_id FROM {alias})"
+                )
+
+        pf = partition_by_column.get(col_name)
+        if pf is not None:
+            cte_sql, cte_params, alias = _build_partition_cte(
+                field=pf,
+                clauses=col_clauses,
+                dialect=dialect,
+            )
+            if cte_sql is not None:
+                partition_ctes.append(cte_sql)
+                params.update(cte_params)
+                where_filters.append(
+                    f"vf.data_file_id IN (SELECT data_file_id FROM {alias})"
+                )
+
+    cte_pieces = [
+        _visible_files_cte(),
+        _visible_deletes_cte(),
+        *stats_ctes,
+        *partition_ctes,
+    ]
+    with_block = "WITH " + ",\n".join(cte_pieces)
+
+    where_clause = ""
+    if where_filters:
+        where_clause = "WHERE " + "\n  AND ".join(where_filters) + "\n"
+
+    sql = (
+        f"{with_block}\n"
+        "SELECT vf.data_file_id, vf.path, vf.path_is_relative,\n"
+        "       vf.record_count, vf.begin_snapshot, vf.partial_max,\n"
+        "       vd.delete_path, vd.delete_path_is_relative\n"
+        "FROM visible_files vf\n"
+        "LEFT JOIN visible_deletes vd USING (data_file_id)\n"
+        f"{where_clause}"
+        "ORDER BY vf.file_order, vd.delete_path"
+    )
+    return sql, params
+
+
+def _visible_files_cte() -> str:
+    return (
+        "visible_files AS (\n"
+        "  SELECT data_file_id, path, path_is_relative, record_count,\n"
+        "         begin_snapshot, partial_max, file_order\n"
+        "  FROM ducklake_data_file\n"
+        f"  WHERE table_id = :table_id AND ({_MVCC})\n"
+        ")"
+    )
+
+
+def _visible_deletes_cte() -> str:
+    return (
+        "visible_deletes AS (\n"
+        "  SELECT data_file_id,\n"
+        "         path AS delete_path,\n"
+        "         path_is_relative AS delete_path_is_relative\n"
+        "  FROM ducklake_delete_file\n"
+        f"  WHERE table_id = :table_id AND ({_MVCC})\n"
+        ")"
+    )
+
+
+def _build_stats_cte(
+    *,
+    column_id: int,
+    column_type: str,
+    clauses: list[_AtomicClause],
+    dialect: str,
+) -> tuple[str | None, dict[str, Any], str]:
+    """Build a per-column stats CTE: file_ids that may match all clauses,
+    UNION'd with file_ids that have no stats row for the column.
+
+    Returns ``(cte_sql, params, alias)``; ``cte_sql`` is ``None`` when
+    no clauses on this column translated.
+    """
+    alias = f"col_{column_id}_stats"
+    parts: list[str] = []
+    params: dict[str, Any] = {f"col_{column_id}_id": column_id}
+    for i, c in enumerate(clauses):
+        translated = translate_clause(
+            c,
+            column_type=column_type,
+            dialect=dialect,
+            param_prefix=f"col_{column_id}_{i}",
+        )
+        if translated is None:
+            continue
+        parts.append(translated.sql)
+        params.update(translated.params)
+    if not parts:
+        return None, {}, alias
+    bound_block = "\n    AND ".join(parts)
+    cte_sql = (
+        f"{alias} AS (\n"
+        "  SELECT data_file_id FROM ducklake_file_column_stats\n"
+        f"  WHERE table_id = :table_id AND column_id = :col_{column_id}_id\n"
+        f"    AND {bound_block}\n"
+        "  UNION ALL\n"
+        "  SELECT data_file_id FROM visible_files\n"
+        "  WHERE data_file_id NOT IN (\n"
+        "    SELECT data_file_id FROM ducklake_file_column_stats\n"
+        f"    WHERE column_id = :col_{column_id}_id\n"
+        "  )\n"
+        ")"
+    )
+    return cte_sql, params, alias
+
+
+def _build_partition_cte(
+    *,
+    field: PartitionField,
+    clauses: list[_AtomicClause],
+    dialect: str,
+) -> tuple[str | None, dict[str, Any], str]:
+    """Build an identity-partition CTE: file_ids whose partition_value
+    matches the clause, UNION'd with files that have no partition_value
+    row for this key (kept conservatively).
+    """
+    pki = field.partition_key_index
+    alias = f"part_{pki}_filter"
+    parts: list[str] = []
+    params: dict[str, Any] = {f"pki_{pki}": pki}
+    for i, c in enumerate(clauses):
+        translated = _translate_partition_clause(
+            c,
+            column_type=field.column_type,
+            dialect=dialect,
+            param_prefix=f"pki_{pki}_{i}",
+        )
+        if translated is None:
+            continue
+        parts.append(translated.sql)
+        params.update(translated.params)
+    if not parts:
+        return None, {}, alias
+    bound_block = "\n    AND ".join(parts)
+    cte_sql = (
+        f"{alias} AS (\n"
+        "  SELECT data_file_id FROM ducklake_file_partition_value\n"
+        f"  WHERE table_id = :table_id AND partition_key_index = :pki_{pki}\n"
+        f"    AND {bound_block}\n"
+        "  UNION ALL\n"
+        "  SELECT vf.data_file_id FROM visible_files vf\n"
+        "  WHERE NOT EXISTS (\n"
+        "    SELECT 1 FROM ducklake_file_partition_value fpv\n"
+        "    WHERE fpv.data_file_id = vf.data_file_id\n"
+        f"      AND fpv.partition_key_index = :pki_{pki}\n"
+        "  )\n"
+        ")"
+    )
+    return cte_sql, params, alias
+
+
+def _translate_partition_clause(
+    clause: _AtomicClause,
+    *,
+    column_type: str,
+    dialect: str,
+    param_prefix: str,
+) -> _ClauseSql | None:
+    """Translate a clause to a single-value match against ``partition_value``.
+
+    Identity-transform only. Files with NULL ``partition_value`` are
+    kept conservatively (the writer may have left it unset).
+    """
+    op = clause.op
+    if op == "is_null":
+        return _ClauseSql("(partition_value IS NULL)", {})
+    if op == "is_not_null":
+        return _ClauseSql("(partition_value IS NOT NULL)", {})
+
+    typed = _typed_stat_expr("partition_value", column_type, dialect)
+    if typed is None:
+        return None
+    bind = _bind_value_for(clause.literal, column_type)
+    if bind is _BIND_UNSUPPORTED:
+        return None
+
+    op_sql = {
+        "eq": "=", "ne": "<>", "lt": "<", "le": "<=", "gt": ">", "ge": ">=",
+    }.get(op)
+    if op_sql is None:
+        return None
+
+    p_name = f"{param_prefix}_v"
+    p_ref = f":{p_name}"
+    return _ClauseSql(
+        sql=f"(partition_value IS NULL OR {typed} {op_sql} {p_ref})",
+        params={p_name: bind},
+    )

--- a/src/polars_ducklake/_predicate.py
+++ b/src/polars_ducklake/_predicate.py
@@ -1,24 +1,18 @@
-"""Catalog-stats predicate pruning.
+"""Predicate AST extraction for catalog-side pushdown.
 
 The Polars IO plugin hands us the user's predicate as a deserialized
-:class:`polars.Expr`. We walk its JSON form and try to extract a flat
-list of "atomic" clauses — each one a ``column <op> literal`` test or
-an ``is_null`` / ``is_not_null`` check, joined only by AND. On anything
-we don't recognize (OR, arithmetic on a column, function calls,
-``is_in``, struct/list ops, etc) we return ``None`` and the caller
-falls back to "don't prune" — Polars will still apply the predicate
-itself on the rows we yield.
+:class:`polars.Expr`. We walk its JSON form and extract a list of
+"atomic" clauses — each one a ``column <op> literal`` test or an
+``is_null`` / ``is_not_null`` check. The walk is lossy by design: we
+keep what we can express in SQL and silently drop anything we don't
+(OR, arithmetic on a column, ``is_in``, struct/list ops, tz-aware
+datetimes, etc). Polars still applies the full predicate to rows we
+yield, so dropping a clause widens the candidate file set without
+changing the result.
 
-For each kept clause we evaluate it against a file's per-column
-``ducklake_file_column_stats`` row (min, max, null counts) and drop the
-file when the clause is provably false everywhere in it. The min/max
-values are stored as VARCHAR by DuckLake's writer; we coerce them to
-typed Python values per the catalog's ``column_type`` so comparisons
-behave correctly (e.g. integer order, not string order).
-
-This is a best-effort layer above Polars' Parquet-level row-group
-pruning: we get to skip files we never open at all, while Polars still
-gets to skip row groups within the files we do open.
+The actual translation from these clauses into the catalog-side CTE
+query lives in :mod:`polars_ducklake._file_query`; this module's job
+is purely to parse the Polars expression tree.
 
 This module is private; behavior may change without notice.
 """
@@ -32,14 +26,12 @@ from typing import Any, Literal
 
 import polars as pl
 
-from polars_ducklake._catalog import FileColumnStat
-
 _Op = Literal["eq", "ne", "lt", "le", "gt", "ge", "is_null", "is_not_null"]
 
 # Polars BinaryExpr op names → our internal op tags. Anything not in this
-# map is unsupported (And is handled separately as a node-splitter; Or is
-# deliberately absent — we'd need to fold disjunctions across files,
-# which we don't.)
+# map is unsupported (And is handled separately as a node-splitter; Or
+# drops both branches because pushing one side of a disjunction would
+# lose files matching only the other side.)
 _BINOP_TO_ATOMIC: dict[str, _Op] = {
     "Eq": "eq",
     "NotEq": "ne",
@@ -48,18 +40,6 @@ _BINOP_TO_ATOMIC: dict[str, _Op] = {
     "Gt": "gt",
     "GtEq": "ge",
 }
-
-# DuckLake catalog column-type strings (lowercased) we know how to coerce.
-_INT_TYPES = {
-    "tinyint", "smallint", "integer", "int", "bigint", "hugeint",
-    "utinyint", "usmallint", "uinteger", "ubigint",
-    "int8", "int16", "int32", "int64",
-    "uint8", "uint16", "uint32", "uint64",
-}
-_FLOAT_TYPES = {
-    "float", "double", "real", "float4", "float8", "float32", "float64",
-}
-_STRING_TYPES = {"varchar", "string", "text"}
 
 _EPOCH = date(1970, 1, 1)
 
@@ -78,65 +58,70 @@ class _AtomicClause:
     literal: Any
 
 
-def extract_clauses(predicate: pl.Expr) -> list[_AtomicClause] | None:
-    """Walk the predicate AST; return its atomic clauses or ``None``.
+def extract_clauses(predicate: pl.Expr) -> list[_AtomicClause]:
+    """Walk the predicate AST; return atomic clauses we can push down.
 
-    Returns ``None`` (caller falls back to no pruning) on any of:
+    Lossy: returns whatever supported leaves we can extract from an outer
+    AND, and silently drops the rest. Anything we don't translate — OR,
+    arithmetic on a column, function calls beyond ``is_null`` /
+    ``is_not_null``, ``is_in``, ``between``, struct/list ops, tz-aware
+    datetimes — is dropped. Polars still applies the full predicate on
+    the rows we yield, so a dropped clause widens the candidate file set
+    without changing the result.
 
-    * top-level OR
-    * arithmetic on a column reference (``col + 1 > 5``)
-    * function calls other than ``is_null`` / ``is_not_null``
-    * ``is_in``, ``between``, struct/list field access, etc
-    * literals we don't know how to coerce (e.g. timezone-aware datetimes)
-
-    Returns ``[]`` (truthy = "no clauses to apply") only if the predicate
-    is structurally empty, which shouldn't happen — Polars wouldn't
-    serialize that — but is harmless if it does.
+    Returns ``[]`` when nothing is pushable (including a top-level OR).
     """
     try:
         node = json.loads(predicate.meta.serialize(format="json"))
     except Exception:
-        return None
+        return []
     out: list[_AtomicClause] = []
-    if not _walk(node, out):
-        return None
+    _walk(node, out)
     return out
 
 
-def _walk(node: Any, out: list[_AtomicClause]) -> bool:
-    """Recursively split ANDs and append atomic clauses. Returns False on
-    the first unsupported subtree we encounter."""
+def _walk(node: Any, out: list[_AtomicClause]) -> None:
+    """Recursively split top-level ANDs and append atomic clauses.
+
+    Drops unsupported subtrees silently. For OR we drop *both* branches:
+    pushing only one side of a disjunction would lose files that match
+    only the other side. AND is the one composing operator we honor —
+    partial extraction across an AND is safe because Polars re-applies
+    the full predicate at read time.
+    """
     if not isinstance(node, dict):
-        return False
+        return
     if "BinaryExpr" in node:
         be = node["BinaryExpr"]
         op = be.get("op")
         if op == "And":
-            # Both sides must be supported; partial extraction would let
-            # us drop files that the *unsupported* side would have kept.
-            return _walk(be["left"], out) and _walk(be["right"], out)
+            _walk(be.get("left"), out)
+            _walk(be.get("right"), out)
+            return
+        if op == "Or":
+            return
         atomic = _BINOP_TO_ATOMIC.get(op)
         if atomic is None:
-            return False
+            return
         col = _as_column(be.get("left"))
         if col is None:
-            return False
+            return
         lit = _as_literal(be.get("right"))
         if lit is _UNSUPPORTED:
-            return False
+            return
         out.append(_AtomicClause(column=col, op=atomic, literal=lit))
-        return True
+        return
     if "Function" in node:
         fn = node["Function"]
         boolean_fn = fn.get("function", {}).get("Boolean")
         if boolean_fn not in ("IsNull", "IsNotNull"):
-            return False
+            return
         inputs = fn.get("input") or []
         if len(inputs) != 1:
-            return False
+            return
         col = _as_column(inputs[0])
         if col is None:
-            return False
+            return
         out.append(
             _AtomicClause(
                 column=col,
@@ -144,8 +129,6 @@ def _walk(node: Any, out: list[_AtomicClause]) -> bool:
                 literal=None,
             )
         )
-        return True
-    return False
 
 
 def _as_column(node: Any) -> str | None:
@@ -219,116 +202,3 @@ def _as_literal(node: Any) -> Any:
     return _UNSUPPORTED
 
 
-def _coerce_stat(raw: str | None, column_type: str) -> Any:
-    """Catalog-VARCHAR → Python value matching the column's logical type.
-
-    Returns ``None`` if ``raw`` is ``None`` (the catalog stored a NULL,
-    e.g. all-null column) or if coercion fails. Callers should treat
-    ``None`` as "no information" and conservatively keep the file.
-    """
-    if raw is None:
-        return None
-    ct = column_type.strip().lower()
-    try:
-        if ct in _INT_TYPES:
-            return int(raw)
-        if ct in _FLOAT_TYPES:
-            return float(raw)
-        if ct in _STRING_TYPES:
-            return raw
-        if ct == "boolean":
-            # DuckLake writes booleans as "0"/"1" in stats.
-            return raw == "1"
-        if ct == "date":
-            return date.fromisoformat(raw)
-        if ct.startswith("timestamp"):
-            # ISO with a space separator; fromisoformat tolerates the
-            # space in 3.11+ but not all minor versions, so normalize.
-            return datetime.fromisoformat(raw.replace(" ", "T"))
-    except (ValueError, TypeError):
-        return None
-    return None
-
-
-def file_can_match(
-    *,
-    stats_by_column: dict[int, FileColumnStat],
-    clauses: list[_AtomicClause],
-    column_meta: dict[str, tuple[int, str]],
-) -> bool:
-    """Decide whether a single data file could possibly match every clause.
-
-    ``stats_by_column`` maps catalog column_id → its stats row for this
-    file (missing keys mean no stats are available for that column on
-    this file). ``column_meta`` maps user-visible column name → (column_id,
-    column_type) so we can look up the right stats row and coerce its
-    min/max correctly.
-
-    Returns ``False`` only when at least one clause is provably false.
-    Anything ambiguous (no stats, NaN-poisoned numerics, unrecognized
-    column types) keeps the file — pruning errs on the side of False
-    negatives, never False positives.
-    """
-    for clause in clauses:
-        meta = column_meta.get(clause.column)
-        if meta is None:
-            # Predicate references a column we don't know about — keep.
-            continue
-        column_id, column_type = meta
-        stat = stats_by_column.get(column_id)
-        if stat is None:
-            continue  # No stats for this column on this file → keep.
-
-        if clause.op == "is_null":
-            if stat.null_count is not None and stat.null_count == 0:
-                return False
-            continue
-        if clause.op == "is_not_null":
-            if (
-                stat.null_count is not None
-                and stat.value_count is not None
-                and stat.null_count == stat.value_count
-            ):
-                return False
-            continue
-
-        # Comparison clauses need typed min/max + a typed literal.
-        # NaN-tainted floats invalidate ordering: keep conservatively.
-        if stat.contains_nan:
-            continue
-
-        cmin = _coerce_stat(stat.min_value, column_type)
-        cmax = _coerce_stat(stat.max_value, column_type)
-        if cmin is None or cmax is None:
-            continue
-        lit = clause.literal
-
-        # If types don't compare cleanly (e.g. int vs str — shouldn't
-        # happen if the predicate is well-formed, but defensive), keep.
-        try:
-            if clause.op == "eq" and (lit < cmin or lit > cmax):
-                return False
-            elif clause.op == "ne":
-                # Only prune if every value equals lit, i.e. min == max == lit.
-                if cmin == cmax == lit:
-                    # Still need to make sure there are non-null values; if
-                    # the column is all nulls, "ne lit" is vacuously true and
-                    # we shouldn't prune.
-                    has_non_null = (
-                        stat.null_count is None
-                        or stat.value_count is None
-                        or stat.value_count > stat.null_count
-                    )
-                    if has_non_null:
-                        return False
-            elif (
-                (clause.op == "lt" and lit <= cmin)
-                or (clause.op == "le" and lit < cmin)
-                or (clause.op == "gt" and lit >= cmax)
-                or (clause.op == "ge" and lit > cmax)
-            ):
-                return False
-        except TypeError:
-            continue
-
-    return True

--- a/src/polars_ducklake/scan.py
+++ b/src/polars_ducklake/scan.py
@@ -25,9 +25,8 @@ for the plugin contract.
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -35,15 +34,14 @@ import polars as pl
 from polars.io.plugins import register_io_source
 
 from polars_ducklake._catalog import (
+    CandidateFile,
     CatalogReader,
     ColumnInfo,
-    DataFileInfo,
-    FileColumnStat,
     SchemaInfo,
     TableInfo,
     _engine_from_metadata_catalog,
 )
-from polars_ducklake._predicate import extract_clauses, file_can_match
+from polars_ducklake._predicate import extract_clauses
 from polars_ducklake.paths import PathSegment, resolve_path
 from polars_ducklake.types import build_nested_type, is_nested_type, map_type
 
@@ -267,7 +265,7 @@ def _plan_file(
     reader: CatalogReader,
     *,
     table_id: int,
-    file: DataFileInfo,
+    file: CandidateFile,
     target_snapshot: int,
     target_columns: list[_TargetColumn],
     full_path: str,
@@ -413,49 +411,18 @@ def _scan_with_deletes(
     )
 
 
-@dataclass(frozen=True)
-class _Resolved:
-    """Cached output of one catalog resolution pass.
-
-    Holds everything the scan needs after the catalog connection has been
-    closed: the user-visible target columns, the per-file plans (paths
-    fully resolved, delete files attached, schema-evolution projections
-    baked in), and the empty/non-empty signal.
-    """
-
-    target_columns: list[_TargetColumn]
-    polars_schema: dict[str, pl.DataType]
-    per_file_plans: list[_FilePlan]
-    has_delete_files: bool
-
-    @property
-    def is_empty(self) -> bool:
-        return not self.per_file_plans
-
-    @property
-    def fast_path_eligible(self) -> bool:
-        """True when every file's schema matches target and no deletes apply.
-
-        Lets us collapse to a single multi-file ``pl.scan_parquet`` so the
-        Polars engine can optimize across files.
-        """
-        return not self.has_delete_files and all(
-            plan.is_pure_passthrough for plan in self.per_file_plans
-        )
-
-
 @dataclass
 class _PlanContext:
     """Lazy bridge between :func:`scan_ducklake`'s arguments and the data
     needed to actually read.
 
     ``snapshot_id`` is required to be already resolved (via
-    :meth:`CatalogReader.resolve_snapshot_id`) — pinning the snapshot at
+    :meth:`CatalogReader.resolve_snapshot`) — pinning the snapshot at
     call time is what makes the resulting LazyFrame reproducible against
-    later catalog commits. All other catalog work (schema/table/columns/
-    files/deletes) is deferred to :meth:`resolve` and memoized so the
-    schema callable and the read generator can both reach for it without
-    paying for it twice.
+    later catalog commits. All deferred catalog work (partition spec,
+    data_path, file enumeration with predicate pushdown, per-file plan
+    construction) runs inside the IO-source generator since file
+    enumeration depends on the predicate Polars hands us at read time.
 
     ``engine`` is the SQLAlchemy ``Engine`` resolved once at scan-build
     time. Storing the engine (rather than the user's original argument)
@@ -472,96 +439,13 @@ class _PlanContext:
     target_columns: list[_TargetColumn]
     storage_options: dict[str, Any] | None
     data_path: str | None
-    _resolved: _Resolved | None = field(default=None, init=False, repr=False)
-
-    def resolve(self, reader: CatalogReader | None = None) -> _Resolved:
-        """Run the deferred catalog phase, optionally on a caller-owned reader.
-
-        When ``reader`` is supplied, all queries run on that connection —
-        the generator passes the reader it already opened so the deferred
-        phase consumes one connection end-to-end. When ``reader`` is
-        ``None`` (e.g. the schema callable invoked outside any generator
-        run), this method opens its own short-lived reader.
-        """
-        if self._resolved is not None:
-            return self._resolved
-        if reader is not None:
-            self._resolved = self._do_resolve(reader)
-            return self._resolved
-        with CatalogReader.from_engine(self.engine) as r:
-            self._resolved = self._do_resolve(r)
-        return self._resolved
-
-    def _do_resolve(self, reader: CatalogReader) -> _Resolved:
-        table_id = self.table_info.table_id
-        target_columns = self.target_columns
-        polars_schema = {tc.name: tc.dtype for tc in target_columns}
-
-        data_files = reader.fetch_data_files(
-            table_id=table_id, snapshot_id=self.snapshot_id
-        )
-        delete_files = reader.fetch_delete_files(
-            table_id=table_id, snapshot_id=self.snapshot_id
-        )
-        effective_data_path = (
-            self.data_path if self.data_path is not None else reader.fetch_data_path()
-        )
-
-        schema_segment = PathSegment(
-            path=self.schema_info.path,
-            is_relative=self.schema_info.path_is_relative,
-        )
-        table_segment = PathSegment(
-            path=self.table_info.path,
-            is_relative=self.table_info.path_is_relative,
-        )
-
-        def _resolve_path(path: str, path_is_relative: bool) -> str:
-            return resolve_path(
-                path=path,
-                path_is_relative=path_is_relative,
-                data_path=effective_data_path,
-                schema_segment=schema_segment,
-                table_segment=table_segment,
-            )
-
-        # Group delete files by the data file they apply to. The catalog
-        # link via data_file_id is authoritative: even if a delete-file
-        # Parquet were to carry rows for multiple data files, the catalog
-        # tells us which data file each catalog row applies to.
-        deletes_by_file: dict[int, list[str]] = defaultdict(list)
-        for df in delete_files:
-            deletes_by_file[df.data_file_id].append(
-                _resolve_path(df.path, df.path_is_relative)
-            )
-
-        per_file_plans = [
-            _plan_file(
-                reader,
-                table_id=table_id,
-                file=f,
-                target_snapshot=self.snapshot_id,
-                target_columns=target_columns,
-                full_path=_resolve_path(f.path, f.path_is_relative),
-                delete_paths=deletes_by_file.get(f.data_file_id, []),
-            )
-            for f in data_files
-        ]
-
-        return _Resolved(
-            target_columns=target_columns,
-            polars_schema=polars_schema,
-            per_file_plans=per_file_plans,
-            has_delete_files=bool(delete_files),
-        )
 
     def _polars_schema(self) -> pl.Schema:
         """Schema callable handed to ``register_io_source``.
 
-        Returns from the eagerly-cached column list — Polars' planner
+        Answers from the eagerly-cached column list — Polars' planner
         invokes this during query optimization and we don't want to open
-        a separate catalog connection just for the schema. File-level
-        work still defers to :meth:`resolve` on the generator's reader.
+        a separate catalog connection just for the schema.
         """
         return pl.Schema({tc.name: tc.dtype for tc in self.target_columns})
 
@@ -602,20 +486,13 @@ def _make_generator(
         n_rows: int | None,
         _batch_size: int | None,
     ) -> Iterator[pl.DataFrame]:
-        # Open one catalog connection for the whole deferred phase: plan
-        # resolution (if not already memoised) and predicate pruning both
-        # run on this reader. The connection stays open across yields and
-        # is released by the context manager when the consumer exhausts
-        # or closes the generator.
+        # One catalog connection for the entire deferred phase: partition
+        # spec, the candidate-file query (with predicate pushdown), and
+        # per-file column lookups for schema evolution. The connection
+        # stays open across yields and is released by the context manager
+        # when the consumer exhausts or closes the generator.
         with CatalogReader.from_engine(ctx.engine) as reader:
-            r = ctx.resolve(reader=reader)
-            plans = r.per_file_plans
-            if predicate is not None:
-                # Catalog-level pruning: drop whole files whose per-column
-                # min/max in the catalog rule out the predicate. Files we
-                # can't decide on (unsupported predicate, missing stats)
-                # fall through and Polars handles the filter itself.
-                plans = _prune_files_by_stats(reader, r, plans, predicate)
+            plans = _build_plans(reader, ctx, predicate)
 
             remaining = n_rows
             for plan in plans:
@@ -641,60 +518,71 @@ def _make_generator(
     return _gen
 
 
-def _prune_files_by_stats(
+def _build_plans(
     reader: CatalogReader,
-    resolved: _Resolved,
-    plans: list[_FilePlan],
-    predicate: pl.Expr,
+    ctx: _PlanContext,
+    predicate: pl.Expr | None,
 ) -> list[_FilePlan]:
-    """Drop files whose catalog stats prove the predicate false.
+    """Run the deferred catalog phase: enumerate candidate files under
+    the predicate, resolve their paths, attach delete files, and bake
+    schema-evolution projections into one :class:`_FilePlan` per file.
 
-    Returns ``plans`` unchanged when:
-
-    * the predicate isn't a flat AND of supported leaves,
-    * none of the leaf columns are visible in the target schema, or
-    * the catalog has no stats rows for the (file, column) pairs we'd
-      check (e.g. the writer didn't emit them).
-
-    Otherwise, fetches stats once for every (referenced column, file)
-    pair and runs :func:`file_can_match` per file.
-
-    ``reader`` is the deferred-phase reader opened by the generator —
-    we share the same connection rather than opening a third one.
+    File enumeration uses the single CTE-shaped query from
+    :mod:`polars_ducklake._file_query`: predicate clauses translate to
+    per-column stats CTEs and identity-partition CTEs, so pruning
+    happens catalog-side in one round trip.
     """
-    clauses = extract_clauses(predicate)
-    if not clauses:
-        return plans
+    table_id = ctx.table_info.table_id
 
-    # Map predicate column names → (column_id, column_type) at the target.
-    target_meta: dict[str, tuple[int, str]] = {
-        tc.name: (tc.column_id, tc.column_type) for tc in resolved.target_columns
-    }
-    referenced_column_ids = {
-        target_meta[c.column][0] for c in clauses if c.column in target_meta
-    }
-    if not referenced_column_ids:
-        # Predicate references only columns that don't exist at the target
-        # snapshot (likely a user mistake — Polars will raise at collect).
-        return plans
-
-    file_ids = [p.data_file_id for p in plans]
-    stats = reader.fetch_file_stats(
-        data_file_ids=file_ids,
-        column_ids=sorted(referenced_column_ids),
+    partition_spec = reader.fetch_partition_spec(
+        table_id=table_id, snapshot_id=ctx.snapshot_id
+    )
+    effective_data_path = (
+        ctx.data_path if ctx.data_path is not None else reader.fetch_data_path()
     )
 
-    # Group stats by data_file_id for the per-file check.
-    by_file: dict[int, dict[int, FileColumnStat]] = defaultdict(dict)
-    for s in stats:
-        by_file[s.data_file_id][s.column_id] = s
+    clauses = extract_clauses(predicate) if predicate is not None else []
+    column_meta: dict[str, tuple[int, str]] = {
+        tc.name: (tc.column_id, tc.column_type) for tc in ctx.target_columns
+    }
+    candidates = reader.fetch_candidate_files(
+        table_id=table_id,
+        snapshot_id=ctx.snapshot_id,
+        column_meta=column_meta,
+        partition_spec=partition_spec,
+        clauses=clauses,
+    )
+
+    schema_segment = PathSegment(
+        path=ctx.schema_info.path,
+        is_relative=ctx.schema_info.path_is_relative,
+    )
+    table_segment = PathSegment(
+        path=ctx.table_info.path,
+        is_relative=ctx.table_info.path_is_relative,
+    )
+
+    def _resolve_path(path: str, path_is_relative: bool) -> str:
+        return resolve_path(
+            path=path,
+            path_is_relative=path_is_relative,
+            data_path=effective_data_path,
+            schema_segment=schema_segment,
+            table_segment=table_segment,
+        )
 
     return [
-        p
-        for p in plans
-        if file_can_match(
-            stats_by_column=by_file.get(p.data_file_id, {}),
-            clauses=clauses,
-            column_meta=target_meta,
+        _plan_file(
+            reader,
+            table_id=table_id,
+            file=cand,
+            target_snapshot=ctx.snapshot_id,
+            target_columns=ctx.target_columns,
+            full_path=_resolve_path(cand.path, cand.path_is_relative),
+            delete_paths=[
+                _resolve_path(d.path, d.path_is_relative)
+                for d in cand.delete_files
+            ],
         )
+        for cand in candidates
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,7 @@ class DuckLakeBuilder:
         self._column_counter = 0
         self._data_file_counter = 0
         self._delete_file_counter = 0
+        self._partition_counter = 0
         # Track each data file's resolved on-disk path so add_delete_file
         # can populate the spec-required (file_path, pos) columns.
         self._data_file_paths: dict[int, Path] = {}
@@ -240,6 +241,34 @@ class DuckLakeBuilder:
                 extra_stats VARCHAR(1024)
             )
             """,
+            # Per the DuckLake spec, partition info is split into a
+            # per-table partition_info row (one per active spec version)
+            # and partition_column rows for each key in the spec. Files
+            # carry their per-key values in file_partition_value.
+            """
+            CREATE TABLE ducklake_partition_info (
+                partition_id BIGINT NOT NULL,
+                table_id BIGINT NOT NULL,
+                begin_snapshot BIGINT NOT NULL,
+                end_snapshot BIGINT
+            )
+            """,
+            """
+            CREATE TABLE ducklake_partition_column (
+                partition_id BIGINT NOT NULL,
+                partition_key_index BIGINT NOT NULL,
+                column_id BIGINT NOT NULL,
+                transform VARCHAR(64) NOT NULL
+            )
+            """,
+            """
+            CREATE TABLE ducklake_file_partition_value (
+                data_file_id BIGINT NOT NULL,
+                table_id BIGINT NOT NULL,
+                partition_key_index BIGINT NOT NULL,
+                partition_value VARCHAR(1024)
+            )
+            """,
             # ``key`` is reserved in MySQL — quote it per-dialect.
             f"""
             CREATE TABLE ducklake_metadata (
@@ -395,6 +424,51 @@ class DuckLakeBuilder:
                 )
         return table_id
 
+    def add_partition(
+        self,
+        *,
+        table_id: int,
+        begin_snapshot: int,
+        columns: list[tuple[int, str]],
+    ) -> int:
+        """Register an identity (or transformed) partition spec for a table.
+
+        ``columns`` is a list of ``(column_id, transform)`` tuples in
+        partition_key_index order. ``transform`` is a string like
+        ``"identity"``, ``"year"``, etc.; the reader/builder only push
+        identity-transform clauses today.
+        """
+        self._partition_counter += 1
+        partition_id = self._partition_counter
+        with self._conn() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO ducklake_partition_info
+                        (partition_id, table_id, begin_snapshot, end_snapshot)
+                    VALUES (:pid, :tid, :begin, NULL)
+                    """
+                ),
+                {"pid": partition_id, "tid": table_id, "begin": begin_snapshot},
+            )
+            for idx, (column_id, transform) in enumerate(columns):
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO ducklake_partition_column
+                            (partition_id, partition_key_index, column_id, transform)
+                        VALUES (:pid, :idx, :cid, :tr)
+                        """
+                    ),
+                    {
+                        "pid": partition_id,
+                        "idx": idx,
+                        "cid": column_id,
+                        "tr": transform,
+                    },
+                )
+        return partition_id
+
     def write_data_file(
         self,
         *,
@@ -405,6 +479,7 @@ class DuckLakeBuilder:
         path_is_relative: bool = True,
         partial_max: int | None = None,
         compute_stats: bool = False,
+        partition_values: dict[int, Any] | None = None,
     ) -> int:
         """Write a Parquet data file and register it in ducklake_data_file.
 
@@ -416,6 +491,10 @@ class DuckLakeBuilder:
         with min/max/null counts derived from ``df``. Used for predicate-
         pruning tests; left off by default so existing fixtures stay
         focused on whatever they're testing.
+
+        ``partition_values`` maps ``partition_key_index → Python value``
+        (stringified per the writer's stat-string rules). Required for
+        files in a partitioned table; ignored otherwise.
         """
         self._data_file_counter += 1
         data_file_id = self._data_file_counter
@@ -452,6 +531,25 @@ class DuckLakeBuilder:
             self._populate_file_column_stats(
                 data_file_id=data_file_id, table_id=table_id, df=df
             )
+        if partition_values:
+            with self._conn() as conn:
+                for key_idx, value in partition_values.items():
+                    conn.execute(
+                        text(
+                            """
+                            INSERT INTO ducklake_file_partition_value
+                                (data_file_id, table_id,
+                                 partition_key_index, partition_value)
+                            VALUES (:dfid, :tid, :idx, :val)
+                            """
+                        ),
+                        {
+                            "dfid": data_file_id,
+                            "tid": table_id,
+                            "idx": key_idx,
+                            "val": _stat_string(value) if value is not None else None,
+                        },
+                    )
         return data_file_id
 
     def _populate_file_column_stats(

--- a/tests/test_connection_count.py
+++ b/tests/test_connection_count.py
@@ -177,3 +177,135 @@ class TestConnectionCount:
         )
         assert df["id"].to_list() == [1, 2, 3, 4]
         assert counts["n"] == 2
+
+
+class TestDeferredQueryCount:
+    """Issue #4: file enumeration is one CTE query, not three.
+
+    Previously the deferred phase issued ``fetch_data_files`` +
+    ``fetch_delete_files`` + (with predicate) ``fetch_file_stats``. The
+    new path collapses these into one ``fetch_candidate_files`` CTE
+    plus a separate ``fetch_partition_spec`` query.
+    """
+
+    @staticmethod
+    def _file_query_counts(engine: sqlalchemy.engine.Engine) -> dict[str, int]:
+        """Tally how often each ducklake_* table is read in this engine.
+
+        Filters to ``ducklake_data_file`` / ``ducklake_delete_file`` /
+        ``ducklake_file_column_stats`` / ``ducklake_partition_*`` so the
+        per-file column lookups (``ducklake_column``) and the snapshot
+        resolution don't muddle the counts.
+        """
+        counts: dict[str, int] = {
+            "ducklake_data_file": 0,
+            "ducklake_delete_file": 0,
+            "ducklake_file_column_stats": 0,
+            "ducklake_partition_info": 0,
+            "ducklake_file_partition_value": 0,
+        }
+
+        @event.listens_for(engine, "before_execute")
+        def _before(
+            conn: Any,
+            clauseelement: Any,
+            multiparams: Any,
+            params: Any,
+            execution_options: Any,
+        ) -> None:
+            sql = str(clauseelement)
+            for table in counts:
+                if table in sql:
+                    counts[table] += 1
+
+        return counts
+
+    def test_collect_with_predicate_runs_one_file_query(
+        self, builder: Any
+    ) -> None:
+        # Build a stats-prunable lake.
+        snap = builder.take_snapshot()
+        schema_id = builder.add_schema(name="main", begin_snapshot=snap)
+        table_id = builder.add_table(
+            schema_id=schema_id,
+            name="t",
+            begin_snapshot=snap,
+            columns=[("id", "INTEGER"), ("v", "VARCHAR")],
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"id": [1, 2, 3], "v": ["a", "b", "c"]}),
+            compute_stats=True,
+        )
+
+        engine = _engine_from_metadata_catalog(builder.url)
+        counts = self._file_query_counts(engine)
+        df = (
+            pdl.scan_ducklake(engine, table="t")
+            .filter(pl.col("id") == 2)
+            .collect()
+        )
+        assert df["v"].to_list() == ["b"]
+        # The single CTE enumeration query references all three of these
+        # tables (visible_files, visible_deletes, per-column stats CTE),
+        # so each is mentioned once. Crucially: not three separate queries.
+        assert counts["ducklake_data_file"] == 1
+        assert counts["ducklake_delete_file"] == 1
+        assert counts["ducklake_file_column_stats"] == 1
+
+    def test_collect_without_predicate_does_not_query_stats(
+        self, single_file_lake: dict[str, Any]
+    ) -> None:
+        # No predicate → no per-column stats CTE → file_column_stats
+        # never appears in the file query.
+        builder = single_file_lake["builder"]
+        engine = _engine_from_metadata_catalog(builder.url)
+        counts = self._file_query_counts(engine)
+        df = pdl.scan_ducklake(engine, table="sales").collect()
+        assert df.height == single_file_lake["row_count"]
+        assert counts["ducklake_file_column_stats"] == 0
+        assert counts["ducklake_data_file"] == 1
+        assert counts["ducklake_delete_file"] == 1
+
+    def test_partitioned_table_loads_spec_and_filters(
+        self, builder: Any
+    ) -> None:
+        # The partition spec is a separate query (one round trip, cached
+        # under issue #6 follow-up).
+        snap = builder.take_snapshot()
+        schema_id = builder.add_schema(name="main", begin_snapshot=snap)
+        table_id = builder.add_table(
+            schema_id=schema_id,
+            name="t",
+            begin_snapshot=snap,
+            columns=[("id", "INTEGER"), ("region", "VARCHAR")],
+        )
+        builder.add_partition(
+            table_id=table_id, begin_snapshot=snap, columns=[(2, "identity")]
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"id": [1, 2], "region": ["us", "us"]}),
+            partition_values={0: "us"},
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"id": [3, 4], "region": ["eu", "eu"]}),
+            partition_values={0: "eu"},
+        )
+        engine = _engine_from_metadata_catalog(builder.url)
+        counts = self._file_query_counts(engine)
+        df = (
+            pdl.scan_ducklake(engine, table="t")
+            .filter(pl.col("region") == "eu")
+            .sort("id")
+            .collect()
+        )
+        assert df["id"].to_list() == [3, 4]
+        # Partition spec query is one round trip; the file query CTE
+        # references partition_value once (the part_X_filter CTE).
+        assert counts["ducklake_partition_info"] == 1
+        assert counts["ducklake_file_partition_value"] == 1

--- a/tests/test_file_query.py
+++ b/tests/test_file_query.py
@@ -1,0 +1,500 @@
+"""Unit tests for the catalog-side file query builder (issue #4).
+
+Tests focus on emitted SQL shape and bind params — the actual SQL
+execution against each backend is exercised by integration tests.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from polars_ducklake._file_query import (
+    _BIND_UNSUPPORTED,
+    PartitionField,
+    _bind_value_for,
+    _column_family,
+    _translate_partition_clause,
+    _typed_stat_expr,
+    build_files_query,
+    translate_clause,
+)
+from polars_ducklake._predicate import _AtomicClause
+
+
+class TestColumnFamily:
+    def test_int(self) -> None:
+        assert _column_family("INTEGER") == "int"
+        assert _column_family("bigint") == "int"
+        assert _column_family("uint64") == "int"
+
+    def test_float(self) -> None:
+        assert _column_family("DOUBLE") == "float"
+        assert _column_family("real") == "float"
+
+    def test_string(self) -> None:
+        assert _column_family("VARCHAR") == ""
+        assert _column_family("text") == ""
+
+    def test_boolean(self) -> None:
+        assert _column_family("BOOLEAN") == ""
+
+    def test_date(self) -> None:
+        assert _column_family("date") == "date"
+
+    def test_timestamp(self) -> None:
+        assert _column_family("timestamp") == "timestamp"
+        assert _column_family("timestamp with time zone") == "timestamp"
+
+    def test_unknown(self) -> None:
+        assert _column_family("blob") is None
+        assert _column_family("json") is None
+
+
+class TestTypedStatExpr:
+    def test_int_postgres(self) -> None:
+        assert _typed_stat_expr("min_value", "bigint", "postgresql") == (
+            "CAST(min_value AS BIGINT)"
+        )
+
+    def test_int_sqlite(self) -> None:
+        assert _typed_stat_expr("min_value", "int", "sqlite") == (
+            "CAST(min_value AS INTEGER)"
+        )
+
+    def test_int_mysql(self) -> None:
+        # MySQL CAST uses SIGNED for int conversion, not BIGINT.
+        assert _typed_stat_expr("max_value", "int", "mysql") == (
+            "CAST(max_value AS SIGNED)"
+        )
+
+    def test_float_dialects(self) -> None:
+        assert _typed_stat_expr("min_value", "double", "postgresql") == (
+            "CAST(min_value AS DOUBLE PRECISION)"
+        )
+        assert _typed_stat_expr("min_value", "float", "duckdb") == (
+            "CAST(min_value AS DOUBLE)"
+        )
+        assert _typed_stat_expr("min_value", "real", "sqlite") == (
+            "CAST(min_value AS REAL)"
+        )
+
+    def test_string_no_cast(self) -> None:
+        # Varchar / text never need a cast — string compare is correct.
+        assert _typed_stat_expr("min_value", "varchar", "postgresql") == "min_value"
+        assert _typed_stat_expr("min_value", "text", "sqlite") == "min_value"
+
+    def test_boolean_no_cast(self) -> None:
+        # Booleans are written as "0"/"1" strings; literal is bound the
+        # same way, so direct string compare is correct.
+        assert _typed_stat_expr("min_value", "boolean", "postgresql") == "min_value"
+
+    def test_date_sqlite_no_cast(self) -> None:
+        # SQLite stores dates as TEXT and compares ISO strings lex-
+        # equivalently to chronological order — no CAST needed.
+        assert _typed_stat_expr("min_value", "date", "sqlite") == "min_value"
+
+    def test_date_postgres_casts(self) -> None:
+        assert _typed_stat_expr("min_value", "date", "postgresql") == (
+            "CAST(min_value AS DATE)"
+        )
+
+    def test_timestamp_mysql_casts_to_datetime(self) -> None:
+        # MySQL's CAST target for timestamps is DATETIME, not TIMESTAMP.
+        assert _typed_stat_expr("min_value", "timestamp", "mysql") == (
+            "CAST(min_value AS DATETIME)"
+        )
+
+    def test_unknown_type_returns_none(self) -> None:
+        assert _typed_stat_expr("min_value", "blob", "postgresql") is None
+
+    def test_unknown_dialect_falls_back(self) -> None:
+        # Unrecognized dialect falls back to postgres-style CAST.
+        assert _typed_stat_expr("min_value", "bigint", "weirdsql") == (
+            "CAST(min_value AS BIGINT)"
+        )
+
+
+class TestBindValue:
+    def test_int_passthrough(self) -> None:
+        assert _bind_value_for(5, "int") == 5
+
+    def test_float_passthrough(self) -> None:
+        assert _bind_value_for(3.14, "double") == 3.14
+
+    def test_string_passthrough(self) -> None:
+        assert _bind_value_for("hello", "varchar") == "hello"
+
+    def test_bool_on_boolean_becomes_string(self) -> None:
+        assert _bind_value_for(True, "boolean") == "1"
+        assert _bind_value_for(False, "boolean") == "0"
+        # Case-insensitive on the catalog type.
+        assert _bind_value_for(True, "BOOLEAN") == "1"
+
+    def test_bool_on_non_boolean_rejected(self) -> None:
+        # bool is a subclass of int — must not silently bind as 1/0
+        # against a numeric column.
+        assert _bind_value_for(True, "bigint") is _BIND_UNSUPPORTED
+
+    def test_date_passthrough(self) -> None:
+        d = date(2024, 3, 15)
+        assert _bind_value_for(d, "date") == d
+
+    def test_datetime_passthrough(self) -> None:
+        dt = datetime(2024, 3, 15, 12, 30)
+        assert _bind_value_for(dt, "timestamp") == dt
+
+
+class TestTranslateClauseNullOps:
+    def test_is_null_no_params(self) -> None:
+        c = translate_clause(
+            _AtomicClause("a", "is_null", None),
+            column_type="int",
+            dialect="postgresql",
+            param_prefix="p",
+        )
+        assert c is not None
+        assert c.params == {}
+        # Drop only when null_count is known to be 0.
+        assert "null_count" in c.sql
+        assert "null_count > 0" in c.sql
+
+    def test_is_not_null_no_params(self) -> None:
+        c = translate_clause(
+            _AtomicClause("a", "is_not_null", None),
+            column_type="int",
+            dialect="postgresql",
+            param_prefix="p",
+        )
+        assert c is not None
+        assert c.params == {}
+        assert "null_count < value_count" in c.sql
+
+
+class TestTranslateClauseComparisons:
+    def test_eq_int_postgres(self) -> None:
+        c = translate_clause(
+            _AtomicClause("a", "eq", 5),
+            column_type="bigint",
+            dialect="postgresql",
+            param_prefix="c1",
+        )
+        assert c is not None
+        assert c.params == {"c1_v": 5}
+        # Both bounds reference the typed cast.
+        assert "CAST(min_value AS BIGINT) <= :c1_v" in c.sql
+        assert "CAST(max_value AS BIGINT) >= :c1_v" in c.sql
+        # NaN + null guards present.
+        assert "contains_nan" in c.sql
+        assert "min_value IS NULL" in c.sql
+
+    def test_eq_string_no_cast(self) -> None:
+        c = translate_clause(
+            _AtomicClause("region", "eq", "us"),
+            column_type="varchar",
+            dialect="postgresql",
+            param_prefix="c0",
+        )
+        assert c is not None
+        assert c.params == {"c0_v": "us"}
+        assert "CAST(" not in c.sql
+
+    def test_eq_bool(self) -> None:
+        c = translate_clause(
+            _AtomicClause("flag", "eq", True),
+            column_type="boolean",
+            dialect="postgresql",
+            param_prefix="cf",
+        )
+        assert c is not None
+        # True translated to "1" string.
+        assert c.params == {"cf_v": "1"}
+
+    def test_lt_uses_min_only(self) -> None:
+        c = translate_clause(
+            _AtomicClause("a", "lt", 100),
+            column_type="int",
+            dialect="postgresql",
+            param_prefix="c2",
+        )
+        assert c is not None
+        assert "min_value AS BIGINT) < :c2_v" in c.sql
+
+    def test_gt_uses_max_only(self) -> None:
+        c = translate_clause(
+            _AtomicClause("a", "gt", 100),
+            column_type="int",
+            dialect="postgresql",
+            param_prefix="c3",
+        )
+        assert c is not None
+        assert "max_value AS BIGINT) > :c3_v" in c.sql
+
+    def test_ne_includes_null_count_carve_out(self) -> None:
+        c = translate_clause(
+            _AtomicClause("a", "ne", 5),
+            column_type="int",
+            dialect="postgresql",
+            param_prefix="c4",
+        )
+        assert c is not None
+        # Drop condition is "min == max == lit AND value_count > null_count".
+        # Negation: <> on either bound, OR all-null.
+        assert "<> :c4_v" in c.sql
+        assert "value_count <= null_count" in c.sql
+
+    def test_unsupported_column_type(self) -> None:
+        c = translate_clause(
+            _AtomicClause("a", "eq", 5),
+            column_type="blob",
+            dialect="postgresql",
+            param_prefix="c5",
+        )
+        assert c is None
+
+    def test_date_clause_postgres(self) -> None:
+        c = translate_clause(
+            _AtomicClause("d", "ge", date(2024, 1, 1)),
+            column_type="date",
+            dialect="postgresql",
+            param_prefix="cd",
+        )
+        assert c is not None
+        assert c.params == {"cd_v": date(2024, 1, 1)}
+        assert "CAST(max_value AS DATE) >= :cd_v" in c.sql
+
+    def test_date_clause_sqlite_no_cast(self) -> None:
+        c = translate_clause(
+            _AtomicClause("d", "ge", date(2024, 1, 1)),
+            column_type="date",
+            dialect="sqlite",
+            param_prefix="cd",
+        )
+        assert c is not None
+        # SQLite compares ISO date strings; no CAST in the bound.
+        assert "max_value >= :cd_v" in c.sql
+        assert "CAST(max_value AS DATE)" not in c.sql
+
+    def test_param_prefix_namespacing(self) -> None:
+        # Two clauses with different prefixes must not collide on bind names.
+        c1 = translate_clause(
+            _AtomicClause("a", "eq", 1),
+            column_type="int",
+            dialect="postgresql",
+            param_prefix="c0",
+        )
+        c2 = translate_clause(
+            _AtomicClause("a", "eq", 2),
+            column_type="int",
+            dialect="postgresql",
+            param_prefix="c1",
+        )
+        assert c1 is not None and c2 is not None
+        assert set(c1.params).isdisjoint(c2.params)
+
+
+class TestTranslatePartitionClause:
+    def test_eq_int(self) -> None:
+        c = _translate_partition_clause(
+            _AtomicClause("yr", "eq", 2024),
+            column_type="int",
+            dialect="postgresql",
+            param_prefix="p0",
+        )
+        assert c is not None
+        assert c.params == {"p0_v": 2024}
+        assert "CAST(partition_value AS BIGINT) = :p0_v" in c.sql
+        # NULL partition_value kept conservatively.
+        assert "partition_value IS NULL OR" in c.sql
+
+    def test_is_null_no_params(self) -> None:
+        c = _translate_partition_clause(
+            _AtomicClause("region", "is_null", None),
+            column_type="varchar",
+            dialect="postgresql",
+            param_prefix="p1",
+        )
+        assert c is not None
+        assert c.params == {}
+        assert c.sql == "(partition_value IS NULL)"
+
+    def test_is_not_null_no_params(self) -> None:
+        c = _translate_partition_clause(
+            _AtomicClause("region", "is_not_null", None),
+            column_type="varchar",
+            dialect="postgresql",
+            param_prefix="p1",
+        )
+        assert c is not None
+        assert c.sql == "(partition_value IS NOT NULL)"
+
+    def test_unsupported_type(self) -> None:
+        c = _translate_partition_clause(
+            _AtomicClause("x", "eq", 1),
+            column_type="blob",
+            dialect="postgresql",
+            param_prefix="p2",
+        )
+        assert c is None
+
+
+class TestBuildFilesQuery:
+    """The full CTE builder. Asserts emitted SQL shape, not execution."""
+
+    def test_no_clauses_emits_just_files_and_deletes(self) -> None:
+        sql, params = build_files_query(
+            table_id=7,
+            snapshot_id=42,
+            column_meta={},
+            partition_spec=[],
+            clauses=[],
+            dialect="postgresql",
+        )
+        assert params == {"table_id": 7, "snapshot_id": 42}
+        # Both visibility CTEs are present.
+        assert "visible_files AS (" in sql
+        assert "visible_deletes AS (" in sql
+        # No predicate CTEs and no WHERE filter.
+        assert "col_" not in sql
+        assert "part_" not in sql
+        assert "WHERE vf." not in sql
+        # MVCC fragment present.
+        assert ":snapshot_id >= begin_snapshot" in sql
+        # Final SELECT shape.
+        assert "FROM visible_files vf" in sql
+        assert "LEFT JOIN visible_deletes vd USING (data_file_id)" in sql
+        assert "ORDER BY vf.file_order, vd.delete_path" in sql
+
+    def test_one_int_clause_emits_stats_cte(self) -> None:
+        sql, params = build_files_query(
+            table_id=7,
+            snapshot_id=42,
+            column_meta={"id": (101, "int")},
+            partition_spec=[],
+            clauses=[_AtomicClause("id", "eq", 5)],
+            dialect="postgresql",
+        )
+        # Stats CTE present and filtered into main SELECT.
+        assert "col_101_stats AS (" in sql
+        assert "vf.data_file_id IN (SELECT data_file_id FROM col_101_stats)" in sql
+        # No-stats UNION fallback present.
+        assert "UNION ALL" in sql
+        assert "data_file_id NOT IN (" in sql
+        # Bind parameters: column_id + clause literal.
+        assert params["col_101_id"] == 101
+        assert params["col_101_0_v"] == 5
+        assert params["table_id"] == 7
+        assert params["snapshot_id"] == 42
+
+    def test_clause_on_unknown_column_dropped(self) -> None:
+        # column_meta has no entry for 'zzz' → clause dropped, no CTE.
+        sql, params = build_files_query(
+            table_id=1,
+            snapshot_id=1,
+            column_meta={"id": (101, "int")},
+            partition_spec=[],
+            clauses=[_AtomicClause("zzz", "eq", 5)],
+            dialect="postgresql",
+        )
+        assert "col_" not in sql
+        assert "WHERE vf." not in sql
+        # Bind params don't include the dropped clause.
+        assert all(not k.startswith("col_") for k in params)
+
+    def test_unsupported_column_type_dropped(self) -> None:
+        sql, params = build_files_query(
+            table_id=1,
+            snapshot_id=1,
+            column_meta={"x": (200, "blob")},
+            partition_spec=[],
+            clauses=[_AtomicClause("x", "eq", 5)],
+            dialect="postgresql",
+        )
+        # Stats CTE not emitted because no clauses translated.
+        assert "col_200_stats AS" not in sql
+        assert "WHERE vf." not in sql
+
+    def test_multiple_clauses_same_column_anded(self) -> None:
+        sql, params = build_files_query(
+            table_id=1,
+            snapshot_id=1,
+            column_meta={"id": (101, "int")},
+            partition_spec=[],
+            clauses=[
+                _AtomicClause("id", "ge", 10),
+                _AtomicClause("id", "le", 100),
+            ],
+            dialect="postgresql",
+        )
+        # One CTE, two clauses AND'd.
+        assert sql.count("col_101_stats AS (") == 1
+        assert "col_101_0_v" in params
+        assert "col_101_1_v" in params
+        # Only one IN filter for this column.
+        assert sql.count(
+            "vf.data_file_id IN (SELECT data_file_id FROM col_101_stats)"
+        ) == 1
+
+    def test_multiple_columns_each_get_their_own_cte(self) -> None:
+        sql, _ = build_files_query(
+            table_id=1,
+            snapshot_id=1,
+            column_meta={"id": (101, "int"), "region": (102, "varchar")},
+            partition_spec=[],
+            clauses=[
+                _AtomicClause("id", "gt", 0),
+                _AtomicClause("region", "eq", "us"),
+            ],
+            dialect="postgresql",
+        )
+        assert "col_101_stats AS (" in sql
+        assert "col_102_stats AS (" in sql
+        assert sql.count("vf.data_file_id IN (SELECT data_file_id FROM col_") == 2
+
+    def test_identity_partition_clause_emits_partition_cte(self) -> None:
+        sql, params = build_files_query(
+            table_id=1,
+            snapshot_id=1,
+            column_meta={"yr": (300, "int")},
+            partition_spec=[
+                PartitionField(
+                    column_id=300,
+                    column_name="yr",
+                    column_type="int",
+                    partition_key_index=0,
+                    transform="identity",
+                ),
+            ],
+            clauses=[_AtomicClause("yr", "eq", 2024)],
+            dialect="postgresql",
+        )
+        # Both CTEs emitted (stats AND partition); they intersect.
+        assert "col_300_stats AS (" in sql
+        assert "part_0_filter AS (" in sql
+        assert "vf.data_file_id IN (SELECT data_file_id FROM col_300_stats)" in sql
+        assert "vf.data_file_id IN (SELECT data_file_id FROM part_0_filter)" in sql
+        # Partition param uses its own namespace.
+        assert params["pki_0_0_v"] == 2024
+
+    def test_non_identity_partition_skipped(self) -> None:
+        # Year transform isn't translatable yet — no partition CTE emitted.
+        sql, _ = build_files_query(
+            table_id=1,
+            snapshot_id=1,
+            column_meta={"ts": (400, "timestamp")},
+            partition_spec=[
+                PartitionField(
+                    column_id=400,
+                    column_name="ts",
+                    column_type="timestamp",
+                    partition_key_index=0,
+                    transform="year",
+                ),
+            ],
+            clauses=[_AtomicClause("ts", "ge", datetime(2024, 1, 1))],
+            dialect="postgresql",
+        )
+        # Stats CTE still emitted (column_meta has the column); no
+        # partition CTE for unsupported transform.
+        assert "col_400_stats AS (" in sql
+        assert "part_0_filter AS (" not in sql
+

--- a/tests/test_predicate.py
+++ b/tests/test_predicate.py
@@ -1,4 +1,4 @@
-"""Unit tests for the predicate AST walker and stats matcher."""
+"""Unit tests for the predicate AST walker."""
 
 from __future__ import annotations
 
@@ -7,13 +7,7 @@ from datetime import date, datetime
 import polars as pl
 import pytest
 
-from polars_ducklake._catalog import FileColumnStat
-from polars_ducklake._predicate import (
-    _AtomicClause,
-    _coerce_stat,
-    extract_clauses,
-    file_can_match,
-)
+from polars_ducklake._predicate import _AtomicClause, extract_clauses
 
 
 class TestExtractClauses:
@@ -81,29 +75,37 @@ class TestExtractClauses:
         c = extract_clauses(pl.col("a") < datetime(2024, 3, 15, 12, 30))
         assert c == [_AtomicClause("a", "lt", datetime(2024, 3, 15, 12, 30))]
 
-    # -- bail-out cases (None) --------------------------------------------
+    # -- lossy drop cases -------------------------------------------------
 
-    def test_or_returns_none(self) -> None:
-        assert extract_clauses((pl.col("a") > 0) | (pl.col("b") == 1)) is None
+    def test_or_drops_both_sides(self) -> None:
+        # Pushing only one side of a disjunction would lose files that
+        # match the other side, so we drop the whole OR.
+        assert extract_clauses((pl.col("a") > 0) | (pl.col("b") == 1)) == []
 
-    def test_arithmetic_on_column_returns_none(self) -> None:
-        assert extract_clauses(pl.col("a") + 1 > 5) is None
+    def test_arithmetic_on_column_drops_clause(self) -> None:
+        assert extract_clauses(pl.col("a") + 1 > 5) == []
 
-    def test_function_other_than_null_check_returns_none(self) -> None:
-        assert extract_clauses(pl.col("a").str.contains("x")) is None
+    def test_function_other_than_null_check_drops_clause(self) -> None:
+        assert extract_clauses(pl.col("a").str.contains("x")) == []
 
-    def test_is_in_returns_none(self) -> None:
+    def test_is_in_drops_clause(self) -> None:
         # Supporting is_in needs decoding the embedded series payload —
-        # not done in v0.2; bail and let Polars handle the predicate.
-        assert extract_clauses(pl.col("a").is_in([1, 2, 3])) is None
+        # not done in v0.2; drop and let Polars handle the predicate.
+        assert extract_clauses(pl.col("a").is_in([1, 2, 3])) == []
 
-    def test_partial_unsupported_branch_taints_whole(self) -> None:
-        # If half of an AND is unsupported we must return None for the
-        # whole thing — partial pruning could drop files that the
-        # unsupported half would have kept.
-        assert (
-            extract_clauses((pl.col("a") > 0) & (pl.col("b").is_in([1, 2]))) is None
-        )
+    def test_partial_unsupported_branch_keeps_supported_half(self) -> None:
+        # AND with one supported and one unsupported leaf: keep the
+        # supported leaf. Polars still applies the full predicate to the
+        # rows we yield, so widening the candidate set is safe.
+        assert extract_clauses(
+            (pl.col("a") > 0) & (pl.col("b").is_in([1, 2]))
+        ) == [_AtomicClause("a", "gt", 0)]
+
+    def test_or_inside_and_is_dropped_other_side_kept(self) -> None:
+        # (A OR B) AND C: drop the OR subtree, keep C.
+        assert extract_clauses(
+            ((pl.col("a") > 0) | (pl.col("b") == 1)) & (pl.col("c") == 9)
+        ) == [_AtomicClause("c", "eq", 9)]
 
     def test_typed_int_literal_after_optimizer_cast(self) -> None:
         # When Polars' optimizer pushes a predicate through a typed
@@ -120,200 +122,6 @@ class TestExtractClauses:
         for dtype in (pl.Float32, pl.Float64):
             expr = pl.col("a") < pl.lit(2.5, dtype=dtype)
             assert extract_clauses(expr) == [_AtomicClause("a", "lt", 2.5)]
-
-
-class TestCoerceStat:
-    def test_int(self) -> None:
-        assert _coerce_stat("42", "int32") == 42
-        assert _coerce_stat("42", "bigint") == 42
-
-    def test_float(self) -> None:
-        assert _coerce_stat("3.14", "double") == 3.14
-
-    def test_string(self) -> None:
-        assert _coerce_stat("hello", "varchar") == "hello"
-
-    def test_bool(self) -> None:
-        # DuckLake writes booleans as "0"/"1" in stats.
-        assert _coerce_stat("0", "boolean") is False
-        assert _coerce_stat("1", "boolean") is True
-
-    def test_date(self) -> None:
-        assert _coerce_stat("2024-03-15", "date") == date(2024, 3, 15)
-
-    def test_timestamp(self) -> None:
-        assert _coerce_stat(
-            "2024-03-15 12:30:45", "timestamp"
-        ) == datetime(2024, 3, 15, 12, 30, 45)
-
-    def test_none_passes_through(self) -> None:
-        assert _coerce_stat(None, "int32") is None
-
-    def test_unrecognized_type_returns_none(self) -> None:
-        assert _coerce_stat("anything", "blob") is None
-
-    def test_malformed_returns_none(self) -> None:
-        assert _coerce_stat("not-a-number", "int32") is None
-
-
-class TestFileCanMatch:
-    """`file_can_match` is the per-file decision: keep or drop."""
-
-    @staticmethod
-    def _stat(
-        column_id: int,
-        *,
-        min_value: str | None = None,
-        max_value: str | None = None,
-        null_count: int | None = 0,
-        value_count: int | None = 100,
-        contains_nan: bool | None = None,
-    ) -> FileColumnStat:
-        return FileColumnStat(
-            data_file_id=1,
-            column_id=column_id,
-            min_value=min_value,
-            max_value=max_value,
-            null_count=null_count,
-            value_count=value_count,
-            contains_nan=contains_nan,
-        )
-
-    def test_eq_outside_range_prunes(self) -> None:
-        stats = {1: self._stat(1, min_value="10", max_value="20")}
-        assert not file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "eq", 5)],
-            column_meta={"a": (1, "int32")},
-        )
-
-    def test_eq_inside_range_keeps(self) -> None:
-        stats = {1: self._stat(1, min_value="10", max_value="20")}
-        assert file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "eq", 15)],
-            column_meta={"a": (1, "int32")},
-        )
-
-    def test_lt_below_min_prunes(self) -> None:
-        stats = {1: self._stat(1, min_value="10", max_value="20")}
-        # col < 10: anything below 10 — but min is 10, so impossible.
-        assert not file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "lt", 10)],
-            column_meta={"a": (1, "int32")},
-        )
-
-    def test_le_at_min_keeps(self) -> None:
-        stats = {1: self._stat(1, min_value="10", max_value="20")}
-        # col <= 10: 10 itself qualifies.
-        assert file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "le", 10)],
-            column_meta={"a": (1, "int32")},
-        )
-
-    def test_gt_above_max_prunes(self) -> None:
-        stats = {1: self._stat(1, min_value="10", max_value="20")}
-        assert not file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "gt", 20)],
-            column_meta={"a": (1, "int32")},
-        )
-
-    def test_string_range_prunes(self) -> None:
-        stats = {1: self._stat(1, min_value="m", max_value="z")}
-        assert not file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "eq", "a")],
-            column_meta={"a": (1, "varchar")},
-        )
-
-    def test_date_range_prunes(self) -> None:
-        stats = {1: self._stat(1, min_value="2024-06-01", max_value="2024-06-30")}
-        assert not file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "eq", date(2024, 1, 1))],
-            column_meta={"a": (1, "date")},
-        )
-
-    def test_is_null_with_no_nulls_prunes(self) -> None:
-        stats = {1: self._stat(1, min_value="1", max_value="9", null_count=0)}
-        assert not file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "is_null", None)],
-            column_meta={"a": (1, "int32")},
-        )
-
-    def test_is_not_null_when_all_null_prunes(self) -> None:
-        stats = {1: self._stat(1, null_count=100, value_count=100)}
-        assert not file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "is_not_null", None)],
-            column_meta={"a": (1, "int32")},
-        )
-
-    def test_no_stats_keeps_conservatively(self) -> None:
-        # No stats row for the column → no information → keep the file.
-        assert file_can_match(
-            stats_by_column={},
-            clauses=[_AtomicClause("a", "eq", 5)],
-            column_meta={"a": (1, "int32")},
-        )
-
-    def test_unknown_column_keeps_conservatively(self) -> None:
-        stats = {1: self._stat(1, min_value="10", max_value="20")}
-        assert file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("zzz", "eq", 5)],
-            column_meta={"a": (1, "int32")},
-        )
-
-    def test_contains_nan_keeps_conservatively(self) -> None:
-        # NaN poisons ordering, so we can't trust min/max.
-        stats = {
-            1: self._stat(
-                1, min_value="1.0", max_value="2.0", contains_nan=True
-            )
-        }
-        assert file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "gt", 100.0)],
-            column_meta={"a": (1, "float64")},
-        )
-
-    def test_multiple_clauses_all_must_pass(self) -> None:
-        stats = {
-            1: self._stat(1, min_value="10", max_value="20"),
-            2: self._stat(2, min_value="m", max_value="z"),
-        }
-        # First clause keeps; second prunes → file is dropped.
-        assert not file_can_match(
-            stats_by_column=stats,
-            clauses=[
-                _AtomicClause("a", "eq", 15),
-                _AtomicClause("b", "eq", "a"),
-            ],
-            column_meta={"a": (1, "int32"), "b": (2, "varchar")},
-        )
-
-    def test_ne_singleton_value_prunes(self) -> None:
-        # All values in this file are exactly 5; "col != 5" can be pruned.
-        stats = {1: self._stat(1, min_value="5", max_value="5", null_count=0)}
-        assert not file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "ne", 5)],
-            column_meta={"a": (1, "int32")},
-        )
-
-    def test_ne_range_keeps(self) -> None:
-        # Range, so some value != 5 exists → can't prune.
-        stats = {1: self._stat(1, min_value="1", max_value="10")}
-        assert file_can_match(
-            stats_by_column=stats,
-            clauses=[_AtomicClause("a", "ne", 5)],
-            column_meta={"a": (1, "int32")},
-        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -918,3 +918,189 @@ class TestDeleteFiles:
         )
         # Original us rows were id=1 and id=2; pos=1 removed id=2; only id=1 left.
         assert df["id"].to_list() == [1]
+
+
+class TestPartitionPruning:
+    """Identity-partition pushdown: equality on a partition column drops
+    files in non-matching partitions before any Parquet I/O."""
+
+    @staticmethod
+    def _build_partitioned_lake(builder: Any) -> int:
+        """Three files in three identity-partitioned regions: us / eu / apac."""
+        snap = builder.take_snapshot()
+        schema_id = builder.add_schema(name="main", begin_snapshot=snap)
+        table_id = builder.add_table(
+            schema_id=schema_id,
+            name="t",
+            begin_snapshot=snap,
+            columns=[("id", "INTEGER"), ("region", "VARCHAR")],
+        )
+        # column_ids: id=1, region=2.
+        builder.add_partition(
+            table_id=table_id,
+            begin_snapshot=snap,
+            columns=[(2, "identity")],
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"id": [1, 2], "region": ["us", "us"]}),
+            partition_values={0: "us"},
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"id": [3, 4], "region": ["eu", "eu"]}),
+            partition_values={0: "eu"},
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"id": [5, 6], "region": ["apac", "apac"]}),
+            partition_values={0: "apac"},
+        )
+        return table_id
+
+    @staticmethod
+    def _spy_scan_parquet(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+        import polars_ducklake.scan as scan_mod
+
+        recorded: list[Any] = []
+        real = scan_mod.pl.scan_parquet
+
+        def spy(path: Any, **kw: Any) -> Any:
+            recorded.append(path)
+            return real(path, **kw)
+
+        monkeypatch.setattr(scan_mod.pl, "scan_parquet", spy)
+        return recorded
+
+    def test_eq_on_partition_column_opens_only_one_file(
+        self, builder: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._build_partitioned_lake(builder)
+        recorded = self._spy_scan_parquet(monkeypatch)
+        df = (
+            pdl.scan_ducklake(builder.url, table="t")
+            .filter(pl.col("region") == "eu")
+            .sort("id")
+            .collect()
+        )
+        assert df["region"].to_list() == ["eu", "eu"]
+        # Only the eu file is opened.
+        assert len(recorded) == 1
+
+    def test_no_predicate_returns_all_partitions(self, builder: Any) -> None:
+        self._build_partitioned_lake(builder)
+        df = pdl.scan_ducklake(builder.url, table="t").sort("id").collect()
+        assert df["id"].to_list() == [1, 2, 3, 4, 5, 6]
+
+    def test_predicate_outside_all_partitions_returns_empty(
+        self, builder: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._build_partitioned_lake(builder)
+        recorded = self._spy_scan_parquet(monkeypatch)
+        df = (
+            pdl.scan_ducklake(builder.url, table="t")
+            .filter(pl.col("region") == "antarctica")
+            .collect()
+        )
+        assert df.height == 0
+        # No file opened — every partition was excluded by the catalog query.
+        assert len(recorded) == 0
+
+    def test_non_identity_partition_falls_through_to_stats(
+        self, builder: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Year-transformed partition: not pushed down today, but the
+        # column also has stats so the predicate still prunes by stats.
+        snap = builder.take_snapshot()
+        schema_id = builder.add_schema(name="main", begin_snapshot=snap)
+        table_id = builder.add_table(
+            schema_id=schema_id,
+            name="t",
+            begin_snapshot=snap,
+            columns=[("yr", "INTEGER")],
+        )
+        builder.add_partition(
+            table_id=table_id, begin_snapshot=snap, columns=[(1, "year")]
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"yr": [2023, 2023]}),
+            compute_stats=True,
+            partition_values={0: 2023},
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"yr": [2024, 2024]}),
+            compute_stats=True,
+            partition_values={0: 2024},
+        )
+        recorded = self._spy_scan_parquet(monkeypatch)
+        df = (
+            pdl.scan_ducklake(builder.url, table="t")
+            .filter(pl.col("yr") == 2024)
+            .collect()
+        )
+        assert df["yr"].to_list() == [2024, 2024]
+        # Stats CTE prunes 2023; only 2024 opened.
+        assert len(recorded) == 1
+
+
+class TestLossyExtraction:
+    """Mixed-AND predicates: supported leaves still prune even when a
+    sibling leaf is something we don't translate (e.g. is_in)."""
+
+    @staticmethod
+    def _spy_scan_parquet(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+        import polars_ducklake.scan as scan_mod
+
+        recorded: list[Any] = []
+        real = scan_mod.pl.scan_parquet
+
+        def spy(path: Any, **kw: Any) -> Any:
+            recorded.append(path)
+            return real(path, **kw)
+
+        monkeypatch.setattr(scan_mod.pl, "scan_parquet", spy)
+        return recorded
+
+    def test_supported_leaf_prunes_when_sibling_unsupported(
+        self, builder: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Two files with disjoint id ranges. Predicate is
+        # (id == 175) & (v.is_in([...])). The is_in side is dropped by
+        # extract_clauses; the id == 175 side still prunes the first file.
+        snap = builder.take_snapshot()
+        schema_id = builder.add_schema(name="main", begin_snapshot=snap)
+        table_id = builder.add_table(
+            schema_id=schema_id,
+            name="t",
+            begin_snapshot=snap,
+            columns=[("id", "INTEGER"), ("v", "VARCHAR")],
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"id": [1, 50, 100], "v": ["a", "b", "c"]}),
+            compute_stats=True,
+        )
+        builder.write_data_file(
+            table_id=table_id,
+            begin_snapshot=snap,
+            df=pl.DataFrame({"id": [150, 175, 200], "v": ["d", "e", "f"]}),
+            compute_stats=True,
+        )
+        recorded = self._spy_scan_parquet(monkeypatch)
+        df = (
+            pdl.scan_ducklake(builder.url, table="t")
+            .filter((pl.col("id") == 175) & pl.col("v").is_in(["e"]))
+            .collect()
+        )
+        # Polars applies the full predicate: row id=175, v=e survives.
+        assert df["id"].to_list() == [175]
+        # The supported leaf (id == 175) pruned the first file.
+        assert len(recorded) == 1


### PR DESCRIPTION
## Summary
- Replace the 3-query deferred phase (`fetch_data_files` + `fetch_delete_files` + `fetch_file_stats`) with one CTE-shaped query in `_file_query.py` that returns predicate-pruned candidate files with attached deletes
- Add identity-partition pushdown via `ducklake_file_partition_value` — equality on a partition column drops files in non-matching partitions before any Parquet I/O
- Make `extract_clauses` lossy: AND'd unsupported leaves no longer disable pruning on their supported siblings (Polars still applies the full predicate at read time)
- Drop `file_can_match`, `_coerce_stat`, `fetch_file_stats`, `FileColumnStat` — Python-side stats matching is gone

## Implementation notes
- Per-clause SQL translation handles int/float/varchar/boolean/date/timestamp with dialect-dispatched CASTs (sqlite/postgresql/mysql/duckdb).
- Each per-column stats CTE includes a `UNION ALL` fallback so files with no `ducklake_file_column_stats` row are kept conservatively, matching the old per-file behavior.
- Delete files come back as multiple rows per data file (one per delete) and are grouped Python-side, avoiding cross-dialect `STRING_AGG`/`GROUP_CONCAT`/`LIST` divergence.
- File enumeration moved into the IO-source generator since the file list is now predicate-dependent.
- Closes #4.

## Test plan
- [x] 49 unit tests in `test_file_query.py` covering per-clause translation, dialect dispatch, full CTE shape, partition CTE emission, dropped clauses
- [x] `TestPartitionPruning` (4 tests) and `TestLossyExtraction` (1 test) in `test_scan.py` proving end-to-end correctness + actual file-open count via `pl.scan_parquet` spy
- [x] `TestDeferredQueryCount` (3 tests) in `test_connection_count.py` confirming the deferred phase runs 1 file query, not 3, and that `ducklake_file_column_stats` isn't queried at all when there's no predicate
- [x] All 271 unit tests pass; 19 integration tests across SQLite/DuckDB/Postgres/MinIO/MySQL pass — cross-dialect SQL is correct
- [x] Existing `TestCatalogStatsPruning` tests pass unchanged against the new path

## Out of scope (follow-ups)
- Non-identity partition transforms (`year`/`month`/`day`/`bucket`) — currently fall through to stats pruning
- Multi-file `pl.scan_parquet([paths])` fast path when no deletes / no schema evolution
- Process-wide cache for partition spec + per-file column lookups (#6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)